### PR TITLE
HTML: Wait for firstPaint before starting to capture frames

### DIFF
--- a/src/modules/html/producer/html_producer.cpp
+++ b/src/modules/html/producer/html_producer.cpp
@@ -88,6 +88,7 @@ class html_client
     spl::shared_ptr<core::frame_factory>                        frame_factory_;
     core::video_format_desc                                     format_desc_;
     bool                                                        gpu_enabled_;
+    bool                                                        wait_for_fp_;
     tbb::concurrent_queue<std::wstring>                         javascript_before_load_;
     std::atomic<bool>                                           loaded_;
     std::atomic<bool>                                           ready_to_render_;
@@ -108,12 +109,14 @@ class html_client
                 const spl::shared_ptr<diagnostics::graph>& graph,
                 core::video_format_desc                    format_desc,
                 bool                                       gpu_enabled,
+                bool                                       wait_for_fp,
                 std::wstring                               url)
         : url_(std::move(url))
         , graph_(graph)
         , frame_factory_(std::move(frame_factory))
         , format_desc_(std::move(format_desc))
         , gpu_enabled_(gpu_enabled)
+        , wait_for_fp_(wait_for_fp)
     {
         graph_->set_color("browser-tick-time", diagnostics::color(0.1f, 1.0f, 0.1f));
         graph_->set_color("tick-time", diagnostics::color(0.0f, 0.6f, 0.9f));
@@ -328,22 +331,38 @@ class html_client
 
         browser_ = std::move(browser);
 
+        if(wait_for_fp_) {
+            if(SetupCDP()) {
+                CASPAR_LOG(info) << print() << L" CDP initialized, waiting for firstPaint";
+            }
+            else {
+                CASPAR_LOG(error) << print() << L" Failed to initialize CDP, will not wait for firstPaint";
+            }
+        }
+    }
+
+    bool SetupCDP() {
         auto host = get_browser_host();
-        if(host != nullptr) {
-            cdp_registration_ = host->AddDevToolsMessageObserver(this);
-
-            if (host->ExecuteDevToolsMethod(0, "Page.enable", nullptr) == 0)
-                CASPAR_LOG(error) << print() << L" failed to enable CDP Page domain";
-
-            // Enable Page lifecycle events to get notified of firstContentfulPaint
-            auto params = CefDictionaryValue::Create();
-            params->SetBool("enabled", true);
-            if (host->ExecuteDevToolsMethod(0, "Page.setLifecycleEventsEnabled", params) == 0)
-                CASPAR_LOG(error) << print() << L" failed to enable Page lifecycle events";
+        if(host == nullptr) {
+            return false;
         }
-        else {
-            CASPAR_LOG(error) << print() << L" Could not initialize CDP, browser host is null";
+
+        auto cdp = host->AddDevToolsMessageObserver(this);
+        if (host->ExecuteDevToolsMethod(0, "Page.enable", nullptr) == 0) {
+            CASPAR_LOG(error) << print() << L" failed to enable CDP Page domain";
+            return false;
         }
+
+        // Enable Page lifecycle events to get notified of firstPaint event
+        auto params = CefDictionaryValue::Create();
+        params->SetBool("enabled", true);
+        if (host->ExecuteDevToolsMethod(0, "Page.setLifecycleEventsEnabled", params) == 0) {
+            CASPAR_LOG(error) << print() << L" failed to enable Page lifecycle events";
+            return false;
+        }
+
+        cdp_registration_ = cdp;
+        return true;
     }
 
     void OnBeforeClose(CefRefPtr<CefBrowser> browser) override
@@ -415,6 +434,8 @@ class html_client
             return;
             
         loaded_ = true;
+        
+        // If we're not waiting for firstPaint, this is the closest we get to a "loaded" event
         if(cdp_registration_ == nullptr) {
             ready_to_render_ = true;
         }
@@ -542,8 +563,9 @@ class html_producer : public core::frame_producer
     {
         html::invoke([&] {
             const bool enable_gpu = env::properties().get(L"configuration.html.enable-gpu", false);
+            const bool wait_for_fp = env::properties().get(L"configuration.html.wait-for-fp", false);
 
-            client_ = new html_client(frame_factory, graph_, format_desc, enable_gpu, url_);
+            client_ = new html_client(frame_factory, graph_, format_desc, enable_gpu, wait_for_fp, url_);
 
             CefWindowInfo window_info;
             window_info.bounds.width                 = format_desc.square_width;

--- a/src/modules/html/producer/html_producer.cpp
+++ b/src/modules/html/producer/html_producer.cpp
@@ -54,7 +54,10 @@
 #pragma warning(disable : 4458)
 #include <include/cef_app.h>
 #include <include/cef_client.h>
+#include <include/cef_devtools_message_observer.h>
+#include <include/cef_registration.h>
 #include <include/cef_render_handler.h>
+#include <include/cef_values.h>
 #pragma warning(pop)
 
 #include <optional>
@@ -71,6 +74,7 @@ class html_client
     , public CefLifeSpanHandler
     , public CefLoadHandler
     , public CefDisplayHandler
+    , public CefDevToolsMessageObserver
 {
     std::wstring                        url_;
     spl::shared_ptr<diagnostics::graph> graph_;
@@ -86,6 +90,7 @@ class html_client
     bool                                                        gpu_enabled_;
     tbb::concurrent_queue<std::wstring>                         javascript_before_load_;
     std::atomic<bool>                                           loaded_;
+    std::atomic<bool>                                           ready_to_render_;
     std::atomic<bool>                                           not_found_;
     std::queue<std::pair<std::int_least64_t, core::draw_frame>> frames_;
     mutable std::mutex                                          frames_mutex_;
@@ -96,6 +101,7 @@ class html_client
     std::int_least64_t last_frame_time_;
 
     CefRefPtr<CefBrowser> browser_;
+    CefRefPtr<CefRegistration> cdp_registration_; // keeps observer alive
 
   public:
     html_client(spl::shared_ptr<core::frame_factory>       frame_factory,
@@ -123,9 +129,10 @@ class html_client
             state_["file/path"] = u8(url_);
         }
 
-        loaded_    = false;
-        not_found_ = false;
-        closing_   = false;
+        loaded_          = false;
+        ready_to_render_ = false;
+        not_found_       = false;
+        closing_         = false;
     }
 
     void reload()
@@ -139,8 +146,8 @@ class html_client
     void close()
     {
         closing_ = true;
-
-        html::invoke([=] {
+        html::invoke([this] {
+            cdp_registration_ = nullptr; // unregister DevTools observer
             if (browser_ != nullptr) {
                 browser_->GetHost()->CloseBrowser(true);
             }
@@ -270,7 +277,7 @@ class html_client
                  int                   width,
                  int                   height) override
     {
-        if (closing_ || not_found_)
+        if (closing_ || not_found_ || !ready_to_render_)
             return;
 
         graph_->set_value("browser-tick-time", paint_timer_.elapsed() * format_desc_.fps * 0.5);
@@ -320,6 +327,23 @@ class html_client
         CASPAR_ASSERT(CefCurrentlyOn(TID_UI));
 
         browser_ = std::move(browser);
+
+        auto host = get_browser_host();
+        if(host != nullptr) {
+            cdp_registration_ = host->AddDevToolsMessageObserver(this);
+
+            if (host->ExecuteDevToolsMethod(0, "Page.enable", nullptr) == 0)
+                CASPAR_LOG(error) << print() << L" failed to enable CDP Page domain";
+
+            // Enable Page lifecycle events to get notified of firstContentfulPaint
+            auto params = CefDictionaryValue::Create();
+            params->SetBool("enabled", true);
+            if (host->ExecuteDevToolsMethod(0, "Page.setLifecycleEventsEnabled", params) == 0)
+                CASPAR_LOG(error) << print() << L" failed to enable Page lifecycle events";
+        }
+        else {
+            CASPAR_LOG(error) << print() << L" Could not initialize CDP, browser host is null";
+        }
     }
 
     void OnBeforeClose(CefRefPtr<CefBrowser> browser) override
@@ -389,8 +413,12 @@ class html_client
     {
         if (not_found_)
             return;
-
+            
         loaded_ = true;
+        if(cdp_registration_ == nullptr) {
+            ready_to_render_ = true;
+        }
+        
         execute_queued_javascript();
     }
 
@@ -449,6 +477,49 @@ class html_client
     {
         return L"html[" + url_ + L"]" + L" " + std::to_wstring(format_desc_.square_width) + L" " +
                std::to_wstring(format_desc_.square_height) + L" " + std::to_wstring(format_desc_.fps);
+    }
+
+    // --- CefDevToolsMessageObserver -----------------------------------------
+
+    // Called on TID_UI for every event pushed by the browser.
+    void OnDevToolsEvent(CefRefPtr<CefBrowser> browser,
+                         const CefString& method,
+                         const void*      message,
+                         size_t           message_size) override
+    {
+        CASPAR_ASSERT(CefCurrentlyOn(TID_UI));
+        
+        CASPAR_LOG(debug) << print() << L" DevTools event: " << method.ToString();
+        if (method == "Page.lifecycleEvent") {
+            // Parse the event name from the JSON payload to find firstPaint.
+            // The payload is: {"frameId":"...","loaderId":"...","name":"firstPaint","timestamp":...}
+            // We do a simple substring search to avoid pulling in a JSON parser.
+            const std::string payload(static_cast<const char*>(message), message_size);
+            CASPAR_LOG(debug) << print() << L" DevTools event payload: " << payload;
+
+            if (payload.find("\"firstPaint\"") != std::string::npos) {
+                ready_to_render_ = true;
+                CASPAR_LOG(info) << print() << L" firstPaint - frame capture started";
+
+                // We can stop listening to DevTools events now, as we only cared about the firstPaint event.
+                if (browser_->GetHost()->ExecuteDevToolsMethod(0, "Page.disable", nullptr) == 0)
+                    CASPAR_LOG(warning) << print() << L" failed to disable CDP Page domain";
+
+                cdp_registration_ = nullptr; // unregister DevTools observer
+            }
+        }
+    }
+
+    // Called on TID_UI with the result of each ExecuteDevToolsMethod call.
+    void OnDevToolsMethodResult(CefRefPtr<CefBrowser> browser,
+                                int                   message_id,
+                                bool                  success,
+                                const void*           message,
+                                size_t                message_size) override
+    {
+        CASPAR_ASSERT(CefCurrentlyOn(TID_UI));
+        const std::string payload(static_cast<const char*>(message), message_size);
+        CASPAR_LOG(debug) << print() << L" DevTools method result: " << success << ",\"" << payload << "\"";
     }
 
     IMPLEMENT_REFCOUNTING(html_client);

--- a/src/shell/casparcg.config
+++ b/src/shell/casparcg.config
@@ -55,6 +55,7 @@
 <html>
     <remote-debugging-port>0 [0|1024-65535]</remote-debugging-port>
     <enable-gpu>false [true|false]</enable-gpu>
+    <wait-for-fp>false [true|false] (wait for first paint before starting to save frames)</wait-for-fp>
 	<angle-backend>gl [|gl|d3d11|d3d9]</angle-backend>
     <cache-path>(CEF writes some caches next to the executable, which can fail depending on permissions. This changes it to use another path)</cache-path>
 </html>


### PR DESCRIPTION
Add usage of [DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/1-3/Page/#event-lifecycleEvent) to wait for [first-paint](https://developer.mozilla.org/en-US/docs/Glossary/First_paint) before starting to save generated frames

* Since this could be considered a breaking change, one needs to opt-in to get this functionality. Add the following to the casparcg.config:
   ```html
    <html>
      <wait-for-fp>true</wait-for-fp>
    </html>
   ```