### PR TITLE
Improve latency traceability

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -48,6 +48,7 @@ set(HEADERS
 		filesystem.h
 		future.h
 		log.h
+		log_throttle.h
 		memory.h
 		memshfl.h
 		param.h

--- a/src/common/log_throttle.h
+++ b/src/common/log_throttle.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2011 Sveriges Television AB <info@casparcg.com>
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with CasparCG. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <functional>
+#include <utility>
+
+namespace caspar {
+
+// Throttles repeated logging of a recurring condition. Call tick() on every
+// occurrence and emit a log entry only when it returns true; call reset()
+// when the underlying condition clears. The first `initial_delay` occurrences
+// are suppressed, then one log is allowed every `period` occurrences, until
+// `max_logs` entries have been emitted — after which the throttle stays
+// silent until reset.
+//
+// If `on_silence` is supplied, it is invoked exactly once on the first tick()
+// following the final permitted log, so a "silencing" notice naturally lands
+// after the caller's last warning in the log. If reset() runs before that
+// next tick, the silencing notice is suppressed.
+class log_throttle
+{
+    int                   counter_         = 0;
+    int                   logs_emitted_    = 0;
+    bool                  silence_pending_ = false;
+    int                   initial_delay_;
+    int                   period_;
+    int                   max_logs_;
+    std::function<void()> on_silence_;
+
+  public:
+    log_throttle(int initial_delay, int period, int max_logs, std::function<void()> on_silence = {})
+        : initial_delay_(initial_delay)
+        , period_(period)
+        , max_logs_(max_logs)
+        , on_silence_(std::move(on_silence))
+    {
+    }
+
+    bool tick()
+    {
+        if (silence_pending_) {
+            silence_pending_ = false;
+            if (on_silence_)
+                on_silence_();
+        }
+        const int prev = counter_++;
+        if (logs_emitted_ >= max_logs_)
+            return false;
+        if (prev < initial_delay_)
+            return false;
+        if ((counter_ - initial_delay_) % period_ != 0)
+            return false;
+        if (++logs_emitted_ == max_logs_)
+            silence_pending_ = true;
+        return true;
+    }
+
+    int count() const { return counter_; }
+
+    void reset()
+    {
+        counter_         = 0;
+        logs_emitted_    = 0;
+        silence_pending_ = false;
+    }
+};
+
+} // namespace caspar

--- a/src/modules/decklink/consumer/decklink_consumer.cpp
+++ b/src/modules/decklink/consumer/decklink_consumer.cpp
@@ -40,6 +40,7 @@
 #include <common/diagnostics/graph.h>
 #include <common/except.h>
 #include <common/executor.h>
+#include <common/log_throttle.h>
 #include <common/timer.h>
 
 #include <tbb/parallel_for.h>
@@ -655,6 +656,13 @@ struct decklink_consumer final : public IDeckLinkVideoOutputCallback
     std::atomic<bool>              abort_request_{false};
     std::shared_ptr<decklink_vanc> vanc_;
 
+    log_throttle video_drain_throttle_{0, 10, 5, [this] {
+                                           CASPAR_LOG(warning) << print() << L" Too many warnings. Silencing.";
+                                       }};
+    log_throttle audio_drain_throttle_{0, 10, 5, [this] {
+                                           CASPAR_LOG(warning) << print() << L" Too many warnings. Silencing.";
+                                       }};
+
   public:
     decklink_consumer(const configuration& config, core::video_format_desc channel_format_desc, int channel_index)
         : channel_index_(channel_index)
@@ -935,12 +943,28 @@ struct decklink_consumer final : public IDeckLinkVideoOutputCallback
                 output_->GetBufferedVideoFrameCount(&buffered);
                 graph_->set_value("buffered-video", static_cast<double>(buffered) / config_.buffer_depth());
 
+                if (buffered == 0) {
+                    if (video_drain_throttle_.tick()) {
+                        CASPAR_LOG(warning) << print() << L" No buffered video frames remaining, risk of under-run";
+                    }
+                } else {
+                    video_drain_throttle_.reset();
+                }
+
                 if (config_.embedded_audio) {
                     output_->GetBufferedAudioSampleFrameCount(&buffered);
                     graph_->set_value("buffered-audio",
                                       static_cast<double>(buffered) /
                                           (decklink_format_desc_.audio_cadence[0] * decklink_format_desc_.field_count *
                                            config_.buffer_depth()));
+
+                    if (buffered == 0) {
+                        if (audio_drain_throttle_.tick()) {
+                            CASPAR_LOG(warning) << print() << L" No buffered audio frames remaining, risk of under-run";
+                        }
+                    } else {
+                        audio_drain_throttle_.reset();
+                    }
                 }
             }
 

--- a/src/modules/ffmpeg/producer/av_input.cpp
+++ b/src/modules/ffmpeg/producer/av_input.cpp
@@ -77,7 +77,6 @@ Input::Input(const std::string& filename, std::shared_ptr<diagnostics::graph> gr
 
 Input::~Input()
 {
-    graph_         = spl::shared_ptr<diagnostics::graph>();
     abort_request_ = true;
     ic_cond_.notify_all();
 

--- a/src/modules/ffmpeg/producer/av_producer.cpp
+++ b/src/modules/ffmpeg/producer/av_producer.cpp
@@ -42,7 +42,6 @@ extern "C" {
 #include <libavutil/opt.h>
 #include <libavutil/pixfmt.h>
 #include <libavutil/samplefmt.h>
-#include <libavutil/channel_layout.h>
 }
 #ifdef _MSC_VER
 #pragma warning(pop)
@@ -601,7 +600,13 @@ struct Filter
                                               AV_PIX_FMT_GBRAP16,
                                               AV_PIX_FMT_NONE};
 #if LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(10, 6, 100) && LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(59, 36, 100)
-            FF(av_opt_set_array(sink, "pixel_formats", AV_OPT_SEARCH_CHILDREN | AV_OPT_ARRAY_REPLACE, 0, FF_ARRAY_ELEMS(pix_fmts) - 1, AV_OPT_TYPE_PIXEL_FMT, pix_fmts));
+            FF(av_opt_set_array(sink,
+                                "pixel_formats",
+                                AV_OPT_SEARCH_CHILDREN | AV_OPT_ARRAY_REPLACE,
+                                0,
+                                FF_ARRAY_ELEMS(pix_fmts) - 1,
+                                AV_OPT_TYPE_PIXEL_FMT,
+                                pix_fmts));
 #else
             FF(av_opt_set_int_list(sink, "pix_fmts", pix_fmts, -1, AV_OPT_SEARCH_CHILDREN));
 #endif
@@ -615,12 +620,24 @@ struct Filter
 #pragma warning(push)
 #pragma warning(disable : 4245)
 #endif
-            const AVSampleFormat sample_fmts[] = {AV_SAMPLE_FMT_S32, AV_SAMPLE_FMT_NONE};
-            const int sample_rates[] = {format_desc.audio_sample_rate, -1};
+            const AVSampleFormat sample_fmts[]  = {AV_SAMPLE_FMT_S32, AV_SAMPLE_FMT_NONE};
+            const int            sample_rates[] = {format_desc.audio_sample_rate, -1};
 
 #if LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(10, 6, 100) && LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(59, 36, 100)
-            FF(av_opt_set_array(sink, "sample_formats", AV_OPT_SEARCH_CHILDREN | AV_OPT_ARRAY_REPLACE, 0, FF_ARRAY_ELEMS(sample_fmts) - 1, AV_OPT_TYPE_SAMPLE_FMT, sample_fmts));
-            FF(av_opt_set_array(sink, "samplerates", AV_OPT_SEARCH_CHILDREN | AV_OPT_ARRAY_REPLACE, 0, FF_ARRAY_ELEMS(sample_rates) - 1, AV_OPT_TYPE_INT, sample_rates));
+            FF(av_opt_set_array(sink,
+                                "sample_formats",
+                                AV_OPT_SEARCH_CHILDREN | AV_OPT_ARRAY_REPLACE,
+                                0,
+                                FF_ARRAY_ELEMS(sample_fmts) - 1,
+                                AV_OPT_TYPE_SAMPLE_FMT,
+                                sample_fmts));
+            FF(av_opt_set_array(sink,
+                                "samplerates",
+                                AV_OPT_SEARCH_CHILDREN | AV_OPT_ARRAY_REPLACE,
+                                0,
+                                FF_ARRAY_ELEMS(sample_rates) - 1,
+                                AV_OPT_TYPE_INT,
+                                sample_rates));
 #else
             FF(av_opt_set_int(sink, "all_channel_counts", 1, AV_OPT_SEARCH_CHILDREN));
             FF(av_opt_set_int_list(sink, "sample_fmts", sample_fmts, -1, AV_OPT_SEARCH_CHILDREN));
@@ -863,9 +880,9 @@ struct AVProducer::Impl
         timer frame_timer;
         timer decode_timer;
 
-        int warning_debounce = 0;
-        uint8_t warning_count    = 0;
-        const uint8_t max_warnings = 5;
+        int           warning_debounce = 0;
+        uint8_t       warning_count    = 0;
+        const uint8_t max_warnings     = 5;
 
         while (!thread_.interruption_requested()) {
             {
@@ -932,7 +949,7 @@ struct AVProducer::Impl
                             CASPAR_LOG(warning) << print() << " Waiting for frame...";
                         }
                         warning_count++;
-                        if(warning_count == max_warnings) {
+                        if (warning_count == max_warnings) {
                             CASPAR_LOG(warning) << print() << " Too many warnings. Silencing.";
                         }
                     }

--- a/src/modules/ffmpeg/producer/av_producer.cpp
+++ b/src/modules/ffmpeg/producer/av_producer.cpp
@@ -738,6 +738,7 @@ struct AVProducer::Impl
     core::frame_geometry::scale_mode scale_mode_;
     int64_t                          frame_count_    = 0;
     bool                             frame_flush_    = true;
+    bool                             preloading_     = true;
     int64_t                          frame_time_     = AV_NOPTS_VALUE;
     int64_t                          frame_duration_ = AV_NOPTS_VALUE;
     core::draw_frame                 frame_;
@@ -751,7 +752,7 @@ struct AVProducer::Impl
     std::optional<caspar::executor> video_executor_;
     std::optional<caspar::executor> audio_executor_;
 
-    int latency_ = 0;
+    int latency_ = -1;
 
     boost::thread thread_;
 
@@ -1049,7 +1050,7 @@ struct AVProducer::Impl
     bool is_ready()
     {
         boost::lock_guard<boost::mutex> lock(buffer_mutex_);
-        return !buffer_.empty() || frame_;
+        return !preloading_ && (!buffer_.empty() || frame_);
     }
 
     core::draw_frame next_frame(const core::video_field field)
@@ -1073,8 +1074,11 @@ struct AVProducer::Impl
                 }
                 return core::draw_frame::still(frame_);
             }
-            graph_->set_tag(diagnostics::tag_severity::WARNING, "underflow");
-            latency_ += 1;
+
+            if (!preloading_) {
+                graph_->set_tag(diagnostics::tag_severity::WARNING, "underflow");
+                latency_ += 1;
+            }
             return core::draw_frame{};
         }
 
@@ -1097,6 +1101,7 @@ struct AVProducer::Impl
         frame_time_     = buffer_[0].pts;
         frame_duration_ = buffer_[0].duration;
         frame_flush_    = false;
+        preloading_     = false;
 
         buffer_.pop_front();
         buffer_cond_.notify_all();

--- a/src/modules/ffmpeg/producer/av_producer.cpp
+++ b/src/modules/ffmpeg/producer/av_producer.cpp
@@ -18,6 +18,7 @@
 #include <common/env.h>
 #include <common/except.h>
 #include <common/executor.h>
+#include <common/log_throttle.h>
 #include <common/os/thread.h>
 #include <common/scope_exit.h>
 #include <common/timer.h>
@@ -881,9 +882,8 @@ struct AVProducer::Impl
         timer frame_timer;
         timer decode_timer;
 
-        int           warning_debounce = 0;
-        uint8_t       warning_count    = 0;
-        const uint8_t max_warnings     = 5;
+        log_throttle frame_wait_throttle(
+            100, 500, 5, [this] { CASPAR_LOG(warning) << print() << " Too many warnings. Silencing."; });
 
         while (!thread_.interruption_requested()) {
             {
@@ -941,7 +941,7 @@ struct AVProducer::Impl
 
             if ((!video_filter_.frame && !video_filter_.eof) || (!audio_filter_.frame && !audio_filter_.eof)) {
                 if (!progress) {
-                    if (warning_debounce++ % 500 == 100 && warning_count < max_warnings) {
+                    if (frame_wait_throttle.tick()) {
                         if (!video_filter_.frame && !video_filter_.eof) {
                             CASPAR_LOG(warning) << print() << " Waiting for video frame...";
                         } else if (!audio_filter_.frame && !audio_filter_.eof) {
@@ -949,19 +949,15 @@ struct AVProducer::Impl
                         } else {
                             CASPAR_LOG(warning) << print() << " Waiting for frame...";
                         }
-                        warning_count++;
-                        if (warning_count == max_warnings) {
-                            CASPAR_LOG(warning) << print() << " Too many warnings. Silencing.";
-                        }
                     }
 
                     // TODO (perf): Avoid live loop.
-                    std::this_thread::sleep_for(std::chrono::milliseconds(warning_debounce > 25 ? 20 : 5));
+                    std::this_thread::sleep_for(std::chrono::milliseconds(frame_wait_throttle.count() > 25 ? 20 : 5));
                 }
                 continue;
             }
 
-            warning_debounce = warning_count = 0;
+            frame_wait_throttle.reset();
 
             // TODO (fix)
             // if (start_ != AV_NOPTS_VALUE && frame.pts < start_) {


### PR DESCRIPTION
* Removes latency warning from ffmpeg producers that hasn't started playing yet
* Extract throttled/capped logging functionality from av_producer to shared util
* Add throttled/capped warning logs for bufer under-runs to decklink consumer

Also includes a fix for a race condition during uninit of ffmpeg producers