### PR TITLE
Deterministic rendering

### DIFF
--- a/src/core/consumer/channel_info.h
+++ b/src/core/consumer/channel_info.h
@@ -28,16 +28,18 @@ namespace caspar::core {
 
 struct channel_info
 {
-    channel_info(int channel_index, common::bit_depth depth, color_space color_space)
+    channel_info(int channel_index, common::bit_depth depth, color_space color_space, bool deterministic = false)
         : index(channel_index)
         , depth(depth)
         , default_color_space(color_space)
+        , deterministic(deterministic)
     {
     }
 
     int               index;
     common::bit_depth depth;
     color_space       default_color_space;
+    bool              deterministic;
 };
 
 } // namespace caspar::core

--- a/src/core/consumer/frame_consumer.h
+++ b/src/core/consumer/frame_consumer.h
@@ -60,6 +60,12 @@ class frame_consumer
     virtual std::wstring print() const = 0;
     virtual std::wstring name() const  = 0;
     virtual bool         has_synchronization_clock() const { return false; }
+
+    // True if this consumer can participate in deterministic frame sync, i.e. its `send`
+    // future will not become ready until the frame has been safely accepted (no drops)
+    // so the channel loop is throttled by the consumer's drain rate.
+    virtual bool supports_deterministic_sync() const { return false; }
+
     virtual int          index() const = 0;
 };
 

--- a/src/core/consumer/frame_consumer_registry.cpp
+++ b/src/core/consumer/frame_consumer_registry.cpp
@@ -99,6 +99,10 @@ class destroy_consumer_proxy : public frame_consumer
     std::wstring         print() const override { return consumer_->print(); }
     std::wstring         name() const override { return consumer_->name(); }
     bool                 has_synchronization_clock() const override { return consumer_->has_synchronization_clock(); }
+    bool                 supports_deterministic_sync() const override
+    {
+        return consumer_->supports_deterministic_sync();
+    }
     int                  index() const override { return consumer_->index(); }
     core::monitor::state state() const override { return consumer_->state(); }
 };
@@ -135,6 +139,10 @@ class print_consumer_proxy : public frame_consumer
     std::wstring         print() const override { return consumer_->print(); }
     std::wstring         name() const override { return consumer_->name(); }
     bool                 has_synchronization_clock() const override { return consumer_->has_synchronization_clock(); }
+    bool                 supports_deterministic_sync() const override
+    {
+        return consumer_->supports_deterministic_sync();
+    }
     int                  index() const override { return consumer_->index(); }
     core::monitor::state state() const override { return consumer_->state(); }
 };

--- a/src/core/consumer/output.cpp
+++ b/src/core/consumer/output.cpp
@@ -32,6 +32,7 @@
 #include <common/memory.h>
 
 #include <chrono>
+#include <functional>
 #include <map>
 #include <optional>
 #include <thread>
@@ -51,6 +52,9 @@ struct output::impl
     std::mutex                                     consumers_mutex_;
     std::map<int, spl::shared_ptr<frame_consumer>> consumers_;
 
+    std::function<void()>             on_consumers_changed_;
+    std::function<void(int port_idx)> on_consumer_error_;
+
     std::optional<time_point_t> time_;
 
   public:
@@ -65,21 +69,38 @@ struct output::impl
 
     void add(int index, spl::shared_ptr<frame_consumer> consumer)
     {
+        if (channel_info_.deterministic && !consumer->supports_deterministic_sync()) {
+            CASPAR_THROW_EXCEPTION(user_error()
+                                   << msg_info(L"Cannot attach consumer that does not support deterministic sync to a "
+                                               L"deterministic channel: " +
+                                               consumer->print()));
+        }
+
         remove(index);
 
         consumer->initialize(format_desc_, channel_info_, index);
 
-        std::lock_guard<std::mutex> lock(consumers_mutex_);
-        consumers_.emplace(index, std::move(consumer));
+        {
+            std::lock_guard<std::mutex> lock(consumers_mutex_);
+            consumers_.emplace(index, std::move(consumer));
+        }
+
+        if (on_consumers_changed_)
+            on_consumers_changed_();
     }
 
     void add(const spl::shared_ptr<frame_consumer>& consumer) { add(consumer->index(), consumer); }
 
     bool remove(int index)
     {
-        std::lock_guard<std::mutex> lock(consumers_mutex_);
-        auto                        count = consumers_.erase(index);
-        return count > 0;
+        bool changed;
+        {
+            std::lock_guard<std::mutex> lock(consumers_mutex_);
+            changed = consumers_.erase(index) > 0;
+        }
+        if (changed && on_consumers_changed_)
+            on_consumers_changed_();
+        return changed;
     }
 
     bool remove(const spl::shared_ptr<frame_consumer>& consumer) { return remove(consumer->index()); }
@@ -106,6 +127,9 @@ struct output::impl
         return consumers_.size();
     }
 
+    void set_on_consumers_changed(std::function<void()> callback) { on_consumers_changed_ = std::move(callback); }
+    void set_on_consumer_error(std::function<void(int)> callback) { on_consumer_error_ = std::move(callback); }
+
     void operator()(const const_frame&             input_frame1,
                     const const_frame&             input_frame2,
                     const core::video_format_desc& format_desc)
@@ -131,6 +155,12 @@ struct output::impl
         // If no frame is provided, this should only happen when the channel has no consumers.
         // Take a shortcut and perform the sleep to let the channel tick correctly.
         if (!input_frame1) {
+            if (channel_info_.deterministic) {
+                // In deterministic mode we never pace by wall-clock; the channel just spins
+                // through frames as fast as the producers/consumers allow.
+                time_.reset();
+                return;
+            }
             if (!time) {
                 time = std::chrono::high_resolution_clock::now();
             } else {
@@ -163,7 +193,19 @@ struct output::impl
             consumers = consumers_;
         }
 
-        auto do_send = [this, &consumers](core::video_field field, const core::const_frame& frame) {
+        auto drop_consumer = [this, &consumers](int index) {
+            consumers.erase(index);
+            {
+                std::lock_guard<std::mutex> lock(consumers_mutex_);
+                consumers_.erase(index);
+            }
+            if (on_consumer_error_)
+                on_consumer_error_(index);
+            if (on_consumers_changed_)
+                on_consumers_changed_();
+        };
+
+        auto do_send = [&](core::video_field field, const core::const_frame& frame) {
             std::map<int, std::future<bool>> futures;
 
             for (auto it = consumers.begin(); it != consumers.end();) {
@@ -174,26 +216,25 @@ struct output::impl
                     CASPAR_LOG_CURRENT_EXCEPTION();
                     auto index = it->first;
                     it         = consumers.erase(it);
-
-                    std::lock_guard<std::mutex> lock(consumers_mutex_);
-                    consumers_.erase(index);
+                    {
+                        std::lock_guard<std::mutex> lock(consumers_mutex_);
+                        consumers_.erase(index);
+                    }
+                    if (on_consumer_error_)
+                        on_consumer_error_(index);
+                    if (on_consumers_changed_)
+                        on_consumers_changed_();
                 }
             }
 
             for (auto& p : futures) {
                 try {
                     if (!p.second.get()) {
-                        consumers.erase(p.first);
-
-                        std::lock_guard<std::mutex> lock(consumers_mutex_);
-                        consumers_.erase(p.first);
+                        drop_consumer(p.first);
                     }
                 } catch (...) {
                     CASPAR_LOG_CURRENT_EXCEPTION();
-                    consumers.erase(p.first);
-
-                    std::lock_guard<std::mutex> lock(consumers_mutex_);
-                    consumers_.erase(p.first);
+                    drop_consumer(p.first);
                 }
             }
         };
@@ -215,7 +256,7 @@ struct output::impl
         const auto needs_sync = std::all_of(
             consumers.begin(), consumers.end(), [](auto& p) { return !p.second->has_synchronization_clock(); });
 
-        if (needs_sync) {
+        if (needs_sync && !channel_info_.deterministic) {
             if (!time) {
                 time = std::chrono::high_resolution_clock::now();
             } else {
@@ -246,6 +287,14 @@ std::future<bool> output::call(int index, const std::vector<std::wstring>& param
     return impl_->call(index, params);
 }
 size_t output::consumer_count() const { return impl_->consumer_count(); }
+void   output::set_on_consumers_changed(std::function<void()> callback)
+{
+    impl_->set_on_consumers_changed(std::move(callback));
+}
+void output::set_on_consumer_error(std::function<void(int)> callback)
+{
+    impl_->set_on_consumer_error(std::move(callback));
+}
 void   output::operator()(const const_frame& frame, const const_frame& frame2, const video_format_desc& format_desc)
 {
     return (*impl_)(frame, frame2, format_desc);

--- a/src/core/consumer/output.h
+++ b/src/core/consumer/output.h
@@ -27,6 +27,7 @@
 #include <common/memory.h>
 #include <core/video_format.h>
 
+#include <functional>
 #include <memory>
 
 namespace caspar::diagnostics {
@@ -57,6 +58,9 @@ class output final
     std::future<bool> call(int index, const std::vector<std::wstring>& params);
 
     size_t consumer_count() const;
+
+    void set_on_consumers_changed(std::function<void()> callback);
+    void set_on_consumer_error(std::function<void(int port_index)> callback);
 
     core::monitor::state state() const;
 

--- a/src/core/producer/color/color_producer.cpp
+++ b/src/core/producer/color/color_producer.cpp
@@ -108,6 +108,7 @@ class color_producer : public frame_producer
     core::monitor::state state() const override { return state_; }
 
     bool is_ready() override { return true; }
+    bool supports_deterministic_sync() const override { return true; }
 };
 
 std::wstring get_hex_color(const std::wstring& str)

--- a/src/core/producer/frame_producer.cpp
+++ b/src/core/producer/frame_producer.cpp
@@ -74,6 +74,7 @@ const spl::shared_ptr<frame_producer>& frame_producer::empty()
         }
 
         bool is_ready() override { return true; }
+        bool supports_deterministic_sync() const override { return true; }
     };
 
     static spl::shared_ptr<frame_producer> producer = spl::make_shared<empty_frame_producer>();

--- a/src/core/producer/frame_producer.h
+++ b/src/core/producer/frame_producer.h
@@ -30,11 +30,13 @@
 #include <core/frame/draw_frame.h>
 #include <core/video_format.h>
 
+#include <chrono>
 #include <cstdint>
 #include <functional>
 #include <future>
 #include <optional>
 #include <string>
+#include <thread>
 #include <type_traits>
 #include <vector>
 
@@ -112,6 +114,34 @@ class frame_producer
      * While this returns false, the previous producer will be left running for a limited number of frames.
      */
     virtual bool is_ready() = 0;
+
+    /**
+     * True if this producer can participate in deterministic frame sync. Producers that are
+     * driven by an external clock (decklink, ndi, cross-channel routes) must return false.
+     * Producers that can be paced by us pulling them (file, image, color, ...) return true.
+     */
+    virtual bool supports_deterministic_sync() const { return false; }
+
+    /**
+     * Block until the next frame is available, or `timeout` elapses.
+     * Returns true if a frame is ready, false on timeout. Default implementation polls
+     * `is_ready()`. Sync-capable producers should override with a condvar-based wait so the
+     * channel does not spin while waiting for a real-time producer to catch up.
+     */
+    virtual bool wait_for_frame(const video_field field, std::chrono::milliseconds timeout)
+    {
+        if (is_ready()) {
+            return true;
+        }
+        const auto deadline = std::chrono::steady_clock::now() + timeout;
+        while (std::chrono::steady_clock::now() < deadline) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            if (is_ready()) {
+                return true;
+            }
+        }
+        return false;
+    }
 };
 
 class const_producer : public core::frame_producer
@@ -151,6 +181,7 @@ class const_producer : public core::frame_producer
     }
 
     bool is_ready() override { return true; }
+    bool supports_deterministic_sync() const override { return true; }
 };
 
 class frame_producer_registry;

--- a/src/core/producer/frame_producer_registry.cpp
+++ b/src/core/producer/frame_producer_registry.cpp
@@ -128,6 +128,11 @@ class destroy_producer_proxy : public frame_producer
     draw_frame           first_frame(const core::video_field field) override { return producer_->first_frame(field); }
     core::monitor::state state() const override { return producer_->state(); }
     bool                 is_ready() override { return producer_->is_ready(); }
+    bool                 supports_deterministic_sync() const override { return producer_->supports_deterministic_sync(); }
+    bool                 wait_for_frame(const core::video_field field, std::chrono::milliseconds timeout) override
+    {
+        return producer_->wait_for_frame(field, timeout);
+    }
 };
 
 spl::shared_ptr<core::frame_producer> do_create_producer(const frame_producer_dependencies&     dependencies,

--- a/src/core/producer/layer.cpp
+++ b/src/core/producer/layer.cpp
@@ -159,6 +159,25 @@ struct layer::impl
             return draw_frame{};
         }
     }
+
+    bool wait_for_foreground(const video_field field, std::chrono::milliseconds timeout)
+    {
+        try {
+            // Resolve any pending follower swap so we wait on the active producer.
+            if (foreground_->following_producer() != core::frame_producer::empty() && field != video_field::b) {
+                foreground_ = foreground_->following_producer();
+            }
+            if (paused_) {
+                return true;
+            }
+            return foreground_->wait_for_frame(field, timeout);
+        } catch (...) {
+            CASPAR_LOG_CURRENT_EXCEPTION();
+            return false;
+        }
+    }
+
+    bool foreground_supports_deterministic_sync() const { return foreground_->supports_deterministic_sync(); }
 };
 
 layer::layer(const core::video_format_desc format_desc)
@@ -193,4 +212,12 @@ spl::shared_ptr<frame_producer> layer::foreground() const { return impl_->foregr
 spl::shared_ptr<frame_producer> layer::background() const { return impl_->background_; }
 bool                            layer::has_background() const { return impl_->background_ != frame_producer::empty(); }
 core::monitor::state            layer::state() const { return impl_->state_; }
+bool layer::wait_for_foreground(const video_field field, std::chrono::milliseconds timeout)
+{
+    return impl_->wait_for_foreground(field, timeout);
+}
+bool layer::foreground_supports_deterministic_sync() const
+{
+    return impl_->foreground_supports_deterministic_sync();
+}
 }} // namespace caspar::core

--- a/src/core/producer/layer.h
+++ b/src/core/producer/layer.h
@@ -28,6 +28,8 @@
 
 #include <common/memory.h>
 
+#include <chrono>
+
 namespace caspar { namespace core {
 
 class layer final
@@ -52,6 +54,13 @@ class layer final
 
     draw_frame receive(const video_field field, int nb_samples);
     draw_frame receive_background(const video_field field, int nb_samples);
+
+    // Block until the foreground producer has a frame ready (deterministic mode).
+    // Returns true if a frame became available, false on timeout.
+    bool wait_for_foreground(const video_field field, std::chrono::milliseconds timeout);
+
+    // True if the foreground producer supports deterministic sync.
+    bool foreground_supports_deterministic_sync() const;
 
     core::monitor::state state() const;
 

--- a/src/core/producer/separated/separated_producer.cpp
+++ b/src/core/producer/separated/separated_producer.cpp
@@ -136,6 +136,24 @@ class separated_producer : public frame_producer
     core::monitor::state state() const override { return state_; }
 
     bool is_ready() override { return key_producer_->is_ready() && fill_producer_->is_ready(); }
+
+    bool supports_deterministic_sync() const override
+    {
+        return key_producer_->supports_deterministic_sync() && fill_producer_->supports_deterministic_sync();
+    }
+
+    bool wait_for_frame(const core::video_field field, std::chrono::milliseconds timeout) override
+    {
+        const auto deadline = std::chrono::steady_clock::now() + timeout;
+        if (!fill_producer_->wait_for_frame(field, timeout)) {
+            return false;
+        }
+        const auto remaining = deadline - std::chrono::steady_clock::now();
+        if (remaining <= std::chrono::milliseconds::zero()) {
+            return key_producer_->is_ready();
+        }
+        return key_producer_->wait_for_frame(field, std::chrono::duration_cast<std::chrono::milliseconds>(remaining));
+    }
 };
 
 spl::shared_ptr<frame_producer> create_separated_producer(const spl::shared_ptr<frame_producer>& fill,

--- a/src/core/producer/stage.cpp
+++ b/src/core/producer/stage.cpp
@@ -210,6 +210,7 @@ struct stage::impl : public std::enable_shared_from_this<impl>
                     if (stalled) {
                         graph_->set_tag(diagnostics::tag_severity::WARNING, "deterministic-stall");
                     }
+                    result.stalled = stalled;
                 }
 
                 for (auto& l : layerVec) {

--- a/src/core/producer/stage.cpp
+++ b/src/core/producer/stage.cpp
@@ -36,6 +36,8 @@
 
 #include <boost/range/adaptors.hpp>
 
+#include <algorithm>
+#include <chrono>
 #include <functional>
 #include <future>
 #include <map>
@@ -51,6 +53,7 @@ struct stage::impl : public std::enable_shared_from_this<impl>
     std::map<int, layer>                layers_;
     std::map<int, tweened_transform>    tweens_;
     std::set<int>                       routeSources;
+    const bool                          deterministic_;
 
     mutable std::mutex      format_desc_mutex_;
     core::video_format_desc format_desc_;
@@ -109,11 +112,18 @@ struct stage::impl : public std::enable_shared_from_this<impl>
     }
 
   public:
-    impl(int channel_index, spl::shared_ptr<diagnostics::graph> graph, const core::video_format_desc& format_desc)
+    impl(int                                channel_index,
+         spl::shared_ptr<diagnostics::graph> graph,
+         const core::video_format_desc&      format_desc,
+         bool                                deterministic)
         : channel_index_(channel_index)
         , graph_(std::move(graph))
+        , deterministic_(deterministic)
         , format_desc_(format_desc)
     {
+        if (deterministic_) {
+            graph_->set_color("deterministic-stall", caspar::diagnostics::color(0.9f, 0.1f, 0.1f));
+        }
     }
 
     const stage_frames operator()(uint64_t                                     frame_number,
@@ -160,6 +170,47 @@ struct stage::impl : public std::enable_shared_from_this<impl>
                 // when running interlaced, both fields are be pulled at once.
                 // This will risk some stutter for freshly created producers, but it lets us tick at 25hz and avoids
                 // amcp changes starting on the second field
+
+                // In deterministic mode, wait for every sync-capable foreground producer to have a frame
+                // ready before pulling. Real-time producers (decklink, ndi, cross-channel routes, ...)
+                // are not waited on; they are sampled as-is. Same-channel routes are sorted to be
+                // received after their source layer in `layerVec`, so by the time we wait for them
+                // here their upstream foreground has already been pulled.
+                if (deterministic_) {
+                    // No wall-clock dependencies in deterministic mode: the wait must
+                    // succeed before we pull, or the layer would fall back to still
+                    // frames and the render would depend on producer warm-up timing.
+                    // The bound is a sanity check against a genuinely hung producer
+                    // (the channel thread is blocked inside this stage executor
+                    // invocation, so it cannot observe shutdown until we return).
+                    // Each sync-capable producer's wait_for_frame is expected to mean
+                    // "ready to deliver", not merely "buffer non-empty".
+                    const auto timeout = std::chrono::seconds(60);
+                    bool       stalled = false;
+                    for (auto& l : layerVec) {
+                        if (!l.second) {
+                            continue;
+                        }
+                        auto p = layers_.find(l.first);
+                        if (p == layers_.end()) {
+                            continue;
+                        }
+                        if (!p->second.foreground_supports_deterministic_sync()) {
+                            continue;
+                        }
+                        if (!p->second.wait_for_foreground(field1, std::chrono::duration_cast<std::chrono::milliseconds>(timeout))) {
+                            stalled = true;
+                        }
+                        if (is_interlaced) {
+                            if (!p->second.wait_for_foreground(video_field::b, std::chrono::duration_cast<std::chrono::milliseconds>(timeout))) {
+                                stalled = true;
+                            }
+                        }
+                    }
+                    if (stalled) {
+                        graph_->set_tag(diagnostics::tag_severity::WARNING, "deterministic-stall");
+                    }
+                }
 
                 for (auto& l : layerVec) {
                     auto p = layers_.find(l.first);
@@ -427,8 +478,11 @@ struct stage::impl : public std::enable_shared_from_this<impl>
     }
 };
 
-stage::stage(int channel_index, spl::shared_ptr<diagnostics::graph> graph, const core::video_format_desc& format_desc)
-    : impl_(new impl(channel_index, std::move(graph), format_desc))
+stage::stage(int                                 channel_index,
+             spl::shared_ptr<diagnostics::graph> graph,
+             const core::video_format_desc&      format_desc,
+             bool                                deterministic)
+    : impl_(new impl(channel_index, std::move(graph), format_desc, deterministic))
 {
 }
 std::future<std::wstring> stage::call(int index, const std::vector<std::wstring>& params)

--- a/src/core/producer/stage.h
+++ b/src/core/producer/stage.h
@@ -114,7 +114,8 @@ class stage final : public stage_base
   public:
     explicit stage(int                                         channel_index,
                    spl::shared_ptr<caspar::diagnostics::graph> graph,
-                   const core::video_format_desc&              format_desc);
+                   const core::video_format_desc&              format_desc,
+                   bool                                        deterministic = false);
 
     const stage_frames operator()(uint64_t                                     frame_number,
                                   std::vector<int>&                            fetch_background,

--- a/src/core/producer/stage.h
+++ b/src/core/producer/stage.h
@@ -60,6 +60,10 @@ struct stage_frames
     int                     nb_samples;
     std::vector<draw_frame> frames;
     std::vector<draw_frame> frames2;
+    // Deterministic mode only: true if a sync-capable foreground producer failed to deliver a
+    // frame within the stall timeout this tick (the layer fell back to a still frame). The
+    // channel uses this to detect a hung render and abort it.
+    bool stalled = false;
 };
 
 /**

--- a/src/core/producer/transition/sting_producer.cpp
+++ b/src/core/producer/transition/sting_producer.cpp
@@ -399,6 +399,34 @@ class sting_producer : public frame_producer
     monitor::state state() const override { return state_; }
 
     bool is_ready() override { return dst_producer_->is_ready(); }
+
+    bool supports_deterministic_sync() const override
+    {
+        return dst_producer_->supports_deterministic_sync() && src_producer_->supports_deterministic_sync() &&
+               mask_producer_->supports_deterministic_sync() && overlay_producer_->supports_deterministic_sync();
+    }
+
+    bool wait_for_frame(const core::video_field field, std::chrono::milliseconds timeout) override
+    {
+        const auto deadline = std::chrono::steady_clock::now() + timeout;
+        auto       wait_one = [&](const spl::shared_ptr<frame_producer>& p) {
+            const auto remaining = deadline - std::chrono::steady_clock::now();
+            if (remaining <= std::chrono::milliseconds::zero()) {
+                return p->is_ready();
+            }
+            return p->wait_for_frame(field,
+                                     std::chrono::duration_cast<std::chrono::milliseconds>(remaining));
+        };
+        if (!wait_one(src_producer_))
+            return false;
+        if (!wait_one(dst_producer_))
+            return false;
+        if (!wait_one(mask_producer_))
+            return false;
+        if (!wait_one(overlay_producer_))
+            return false;
+        return true;
+    }
 };
 
 spl::shared_ptr<frame_producer> create_sting_producer(const frame_producer_dependencies&     dependencies,

--- a/src/core/producer/transition/transition_producer.cpp
+++ b/src/core/producer/transition/transition_producer.cpp
@@ -368,6 +368,25 @@ class transition_producer : public frame_producer
     [[nodiscard]] core::monitor::state state() const override { return state_; }
 
     bool is_ready() override { return dst_producer_->is_ready(); }
+
+    bool supports_deterministic_sync() const override
+    {
+        return dst_producer_->supports_deterministic_sync() && src_producer_->supports_deterministic_sync();
+    }
+
+    bool wait_for_frame(const core::video_field field, std::chrono::milliseconds timeout) override
+    {
+        // Both source and destination may be drawn during a transition.
+        const auto deadline = std::chrono::steady_clock::now() + timeout;
+        if (!src_producer_->wait_for_frame(field, timeout)) {
+            return false;
+        }
+        const auto remaining = deadline - std::chrono::steady_clock::now();
+        if (remaining <= std::chrono::milliseconds::zero()) {
+            return dst_producer_->is_ready();
+        }
+        return dst_producer_->wait_for_frame(field, std::chrono::duration_cast<std::chrono::milliseconds>(remaining));
+    }
 };
 
 spl::shared_ptr<frame_producer> create_transition_producer(const spl::shared_ptr<frame_producer>& destination,

--- a/src/core/video_channel.cpp
+++ b/src/core/video_channel.cpp
@@ -41,10 +41,13 @@
 #include <core/diagnostics/call_context.h>
 #include <core/mixer/image/image_mixer.h>
 
+#include <condition_variable>
+#include <map>
 #include <mutex>
 #include <string>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 namespace caspar { namespace core {
 
@@ -74,6 +77,12 @@ struct video_channel::impl final
     std::map<route_id, std::weak_ptr<core::route>> routes_;
     std::mutex                                     routes_mutex_;
 
+    std::multimap<uint64_t, std::function<void()>> schedule_;
+    std::mutex                                     schedule_mutex_;
+
+    std::mutex              tick_mutex_;
+    std::condition_variable tick_cv_;
+
     std::atomic<bool> abort_request_{false};
     std::thread       thread_;
 
@@ -102,13 +111,14 @@ struct video_channel::impl final
     impl(int                                       index,
          const core::video_format_desc&            format_desc,
          color_space                               default_color_space,
+         bool                                      deterministic,
          std::unique_ptr<image_mixer>              image_mixer,
          std::function<void(core::monitor::state)> tick)
-        : channel_info_(index, image_mixer->depth(), default_color_space)
+        : channel_info_(index, image_mixer->depth(), default_color_space, deterministic)
         , output_(graph_, format_desc, channel_info_)
         , image_mixer_(std::move(image_mixer))
         , mixer_(index, graph_, image_mixer_)
-        , stage_(std::make_shared<core::stage>(index, graph_, format_desc))
+        , stage_(std::make_shared<core::stage>(index, graph_, format_desc, deterministic))
         , tick_(std::move(tick))
     {
         graph_->set_color("produce-time", caspar::diagnostics::color(0.0f, 1.0f, 0.0f));
@@ -121,15 +131,54 @@ struct video_channel::impl final
 
         CASPAR_LOG(info) << print() << " Successfully Initialized.";
 
+        // Wake the channel thread whenever consumers attach or detach, so a deterministic
+        // channel can resume ticking when a consumer is added (or pause when the last one
+        // leaves).
+        output_.set_on_consumers_changed([this] {
+            std::lock_guard<std::mutex> lock(tick_mutex_);
+            tick_cv_.notify_all();
+        });
+
         thread_ = std::thread([=] {
             set_thread_realtime_priority();
             set_thread_name(L"channel-" + std::to_wstring(channel_info_.index));
 
             while (!abort_request_) {
                 try {
+                    // In deterministic mode, only tick while at least one consumer is attached.
+                    // Without a consumer there is no demand for frames, and ticking would
+                    // race past any pending scheduled commands.
+                    if (channel_info_.deterministic) {
+                        std::unique_lock<std::mutex> lock(tick_mutex_);
+                        tick_cv_.wait(lock, [this] { return abort_request_.load() || output_.consumer_count() > 0; });
+                        if (abort_request_)
+                            break;
+                    }
+
                     graph_->set_text(print());
 
                     frame_counter_ += 1;
+
+                    // Drain any scheduled actions due at or before this frame so
+                    // they are applied to stage state before we produce frame N.
+                    {
+                        std::vector<std::function<void()>> due;
+                        {
+                            std::lock_guard<std::mutex> lock(schedule_mutex_);
+                            auto                        it = schedule_.begin();
+                            while (it != schedule_.end() && it->first <= frame_counter_) {
+                                due.push_back(std::move(it->second));
+                                it = schedule_.erase(it);
+                            }
+                        }
+                        for (auto& action : due) {
+                            try {
+                                action();
+                            } catch (...) {
+                                CASPAR_LOG_CURRENT_EXCEPTION();
+                            }
+                        }
+                    }
 
                     caspar::timer frame_timer;
 
@@ -199,6 +248,10 @@ struct video_channel::impl final
     {
         CASPAR_LOG(info) << print() << " Uninitializing.";
         abort_request_ = true;
+        {
+            std::lock_guard<std::mutex> lock(tick_mutex_);
+            tick_cv_.notify_all();
+        }
         thread_.join();
     }
 
@@ -229,6 +282,12 @@ struct video_channel::impl final
         return route;
     }
 
+    void schedule_at(uint64_t frame_number, std::function<void()> action)
+    {
+        std::lock_guard<std::mutex> lock(schedule_mutex_);
+        schedule_.emplace(frame_number, std::move(action));
+    }
+
     std::wstring print() const
     {
         return L"video_channel[" + std::to_wstring(channel_info_.index) + L"|" + stage_->video_format_desc().name +
@@ -243,9 +302,10 @@ struct video_channel::impl final
 video_channel::video_channel(int                                       index,
                              const core::video_format_desc&            format_desc,
                              color_space                               default_color_space,
+                             bool                                      deterministic,
                              std::unique_ptr<image_mixer>              image_mixer,
                              std::function<void(core::monitor::state)> tick)
-    : impl_(new impl(index, format_desc, default_color_space, std::move(image_mixer), std::move(tick)))
+    : impl_(new impl(index, format_desc, default_color_space, deterministic, std::move(image_mixer), std::move(tick)))
 {
 }
 video_channel::~video_channel() {}
@@ -261,5 +321,10 @@ channel_info         video_channel::get_consumer_channel_info() const { return i
 core::monitor::state video_channel::state() const { return impl_->state_; }
 
 std::shared_ptr<route> video_channel::route(int index, route_mode mode) { return impl_->route(index, mode); }
+
+void video_channel::schedule_at(uint64_t frame_number, std::function<void()> action)
+{
+    impl_->schedule_at(frame_number, std::move(action));
+}
 
 }} // namespace caspar::core

--- a/src/core/video_channel.cpp
+++ b/src/core/video_channel.cpp
@@ -70,7 +70,7 @@ struct video_channel::impl final
     caspar::core::mixer          mixer_;
     std::shared_ptr<core::stage> stage_;
 
-    uint64_t frame_counter_ = 0;
+    std::atomic<uint64_t> frame_counter_{0}; // atomic: read cross-thread by frame_number()
 
     std::function<void(core::monitor::state)> tick_;
 
@@ -85,6 +85,15 @@ struct video_channel::impl final
 
     std::atomic<bool> abort_request_{false};
     std::thread       thread_;
+
+    // Deterministic hung-render watchdog. If the stage reports a stall (a sync producer failed
+    // to deliver within the stall timeout) for this many consecutive frames, the render is
+    // considered hung: we invoke on_stalled_ (which tears the channel down off-thread) and exit
+    // the tick loop. Each stalled frame already costs the stage's wait timeout, so this is a
+    // backstop — SCHEDULE CANCEL is the immediate path.
+    static constexpr int                  deterministic_stall_abort_frames_ = 3;
+    int                                   consecutive_stalls_               = 0;
+    std::function<void()>                 on_stalled_;
 
     std::function<void(int, const layer_frame&)> routesCb = [&](int layer, const layer_frame& layer_frame) {
         std::lock_guard<std::mutex> lock(routes_mutex_);
@@ -203,6 +212,23 @@ struct video_channel::impl final
                     auto          stage_frames = (*stage_)(frame_counter_, background_routes, routesCb);
                     graph_->set_value("produce-time", produce_timer.elapsed() * format_desc.hz * 0.5);
 
+                    // Hung-render watchdog (deterministic only). A stall means a sync producer
+                    // could not deliver and the frame fell back to a still — the render is no
+                    // longer deterministic. After enough consecutive stalls, abort: hand off
+                    // teardown to the owner (off-thread, so ~video_channel does not self-join
+                    // this thread) and stop ticking.
+                    if (channel_info_.deterministic && stage_frames.stalled) {
+                        if (++consecutive_stalls_ >= deterministic_stall_abort_frames_ && on_stalled_) {
+                            CASPAR_LOG(error)
+                                << print() << L" deterministic render stalled for " << consecutive_stalls_
+                                << L" consecutive frames; aborting render.";
+                            on_stalled_();
+                            break;
+                        }
+                    } else {
+                        consecutive_stalls_ = 0;
+                    }
+
                     // This is a little race prone, but at worst a new consumer will start with a frame of black
                     bool has_consumers = output_.consumer_count() > 0;
 
@@ -288,6 +314,8 @@ struct video_channel::impl final
         schedule_.emplace(frame_number, std::move(action));
     }
 
+    void set_on_deterministic_stall(std::function<void()> callback) { on_stalled_ = std::move(callback); }
+
     std::wstring print() const
     {
         return L"video_channel[" + std::to_wstring(channel_info_.index) + L"|" + stage_->video_format_desc().name +
@@ -295,6 +323,8 @@ struct video_channel::impl final
     }
 
     int index() const { return channel_info_.index; }
+
+    uint64_t frame_number() const { return frame_counter_.load(); }
 
     channel_info get_consumer_channel_info() const { return channel_info_; }
 };
@@ -317,6 +347,7 @@ const output&                       video_channel::output() const { return impl_
 output&                             video_channel::output() { return impl_->output_; }
 spl::shared_ptr<frame_factory>      video_channel::frame_factory() { return impl_->image_mixer_; }
 int                                 video_channel::index() const { return impl_->index(); }
+uint64_t                            video_channel::frame_number() const { return impl_->frame_number(); }
 channel_info         video_channel::get_consumer_channel_info() const { return impl_->get_consumer_channel_info(); };
 core::monitor::state video_channel::state() const { return impl_->state_; }
 
@@ -325,6 +356,11 @@ std::shared_ptr<route> video_channel::route(int index, route_mode mode) { return
 void video_channel::schedule_at(uint64_t frame_number, std::function<void()> action)
 {
     impl_->schedule_at(frame_number, std::move(action));
+}
+
+void video_channel::set_on_deterministic_stall(std::function<void()> callback)
+{
+    impl_->set_on_deterministic_stall(std::move(callback));
 }
 
 }} // namespace caspar::core

--- a/src/core/video_channel.h
+++ b/src/core/video_channel.h
@@ -74,6 +74,7 @@ class video_channel final
     explicit video_channel(int                                       index,
                            const video_format_desc&                  format_desc,
                            color_space                               default_color_space,
+                           bool                                      deterministic,
                            std::unique_ptr<image_mixer>              image_mixer,
                            std::function<void(core::monitor::state)> on_tick);
     ~video_channel();
@@ -94,6 +95,8 @@ class video_channel final
     [[nodiscard]] channel_info get_consumer_channel_info() const;
 
     std::shared_ptr<core::route> route(int index = -1, route_mode mode = route_mode::foreground);
+
+    void schedule_at(uint64_t frame_number, std::function<void()> action);
 
   private:
     struct impl;

--- a/src/core/video_channel.h
+++ b/src/core/video_channel.h
@@ -92,11 +92,20 @@ class video_channel final
 
     int index() const;
 
+    // Number of frames produced so far (deterministic renders use this as the render progress).
+    uint64_t frame_number() const;
+
     [[nodiscard]] channel_info get_consumer_channel_info() const;
 
     std::shared_ptr<core::route> route(int index = -1, route_mode mode = route_mode::foreground);
 
     void schedule_at(uint64_t frame_number, std::function<void()> action);
+
+    // Deterministic mode only: invoked from the channel thread when the render has stalled
+    // (a sync producer failed to deliver) for too many consecutive frames, signalling that the
+    // owner should tear the channel down. Must destroy the channel off-thread (never from the
+    // callback itself) to avoid self-joining the channel thread.
+    void set_on_deterministic_stall(std::function<void()> callback);
 
   private:
     struct impl;

--- a/src/modules/ffmpeg/consumer/ffmpeg_consumer.cpp
+++ b/src/modules/ffmpeg/consumer/ffmpeg_consumer.cpp
@@ -223,7 +223,13 @@ struct Stream
             int nb_pix_fmts = 0;
             for (const auto* p = codec->pix_fmts; *p != AV_PIX_FMT_NONE; ++p, ++nb_pix_fmts)
                 ;
-            FF(av_opt_set_array(sink, "pixel_formats", AV_OPT_SEARCH_CHILDREN | AV_OPT_ARRAY_REPLACE, 0, nb_pix_fmts, AV_OPT_TYPE_PIXEL_FMT, codec->pix_fmts));
+            FF(av_opt_set_array(sink,
+                                "pixel_formats",
+                                AV_OPT_SEARCH_CHILDREN | AV_OPT_ARRAY_REPLACE,
+                                0,
+                                nb_pix_fmts,
+                                AV_OPT_TYPE_PIXEL_FMT,
+                                codec->pix_fmts));
 #else
             FF(av_opt_set_int_list(sink, "pix_fmts", codec->pix_fmts, -1, AV_OPT_SEARCH_CHILDREN));
 #endif
@@ -243,12 +249,24 @@ struct Stream
             int nb_sample_fmts = 0;
             for (const auto* p = codec->sample_fmts; *p != AV_SAMPLE_FMT_NONE; ++p, ++nb_sample_fmts)
                 ;
-            FF(av_opt_set_array(sink, "sample_formats", AV_OPT_SEARCH_CHILDREN | AV_OPT_ARRAY_REPLACE, 0, nb_sample_fmts, AV_OPT_TYPE_SAMPLE_FMT, codec->sample_fmts));
+            FF(av_opt_set_array(sink,
+                                "sample_formats",
+                                AV_OPT_SEARCH_CHILDREN | AV_OPT_ARRAY_REPLACE,
+                                0,
+                                nb_sample_fmts,
+                                AV_OPT_TYPE_SAMPLE_FMT,
+                                codec->sample_fmts));
 
             int nb_sample_rates = 0;
             for (const auto* p = codec->supported_samplerates; p && *p != 0; ++p, ++nb_sample_rates)
                 ;
-            FF(av_opt_set_array(sink, "samplerates", AV_OPT_SEARCH_CHILDREN | AV_OPT_ARRAY_REPLACE, 0, nb_sample_rates, AV_OPT_TYPE_INT, codec->supported_samplerates));
+            FF(av_opt_set_array(sink,
+                                "samplerates",
+                                AV_OPT_SEARCH_CHILDREN | AV_OPT_ARRAY_REPLACE,
+                                0,
+                                nb_sample_rates,
+                                AV_OPT_TYPE_INT,
+                                codec->supported_samplerates));
 #else
             FF(av_opt_set_int_list(sink, "sample_fmts", codec->sample_fmts, -1, AV_OPT_SEARCH_CHILDREN));
             FF(av_opt_set_int_list(sink, "sample_rates", codec->supported_samplerates, 0, AV_OPT_SEARCH_CHILDREN));
@@ -422,14 +440,18 @@ struct ffmpeg_consumer : public core::frame_consumer
     std::future<void> offline_timeout_;
 
     common::bit_depth depth_;
+    bool              deterministic_ = false;
 
   public:
     ffmpeg_consumer(std::string path, std::string args, bool realtime, common::bit_depth depth)
-        : channel_info_([&] {
-            boost::crc_16_type result;
-            result.process_bytes(path.data(), path.length());
-            return result.checksum();
-        }(), depth, caspar::core::color_space::bt709)
+        : channel_info_(
+              [&] {
+                  boost::crc_16_type result;
+                  result.process_bytes(path.data(), path.length());
+                  return result.checksum();
+              }(),
+              depth,
+              caspar::core::color_space::bt709)
         , realtime_(realtime)
         , path_(std::move(path))
         , args_(std::move(args))
@@ -465,8 +487,9 @@ struct ffmpeg_consumer : public core::frame_consumer
         }
 
         format_desc_   = format_desc;
-        channel_info_ = channel_info;
+        channel_info_  = channel_info;
         port_index_    = port_index;
+        deterministic_ = channel_info.deterministic;
 
         graph_->set_text(print());
 
@@ -687,7 +710,11 @@ struct ffmpeg_consumer : public core::frame_consumer
             }
         }
 
-        if (!frame_buffer_.try_push({frame, video_pts, audio_pts})) {
+        if (deterministic_) {
+            // Block until the writer thread accepts the frame. This provides back-pressure
+            // to the channel loop so we never drop frames in deterministic render mode.
+            frame_buffer_.push({frame, video_pts, audio_pts});
+        } else if (!frame_buffer_.try_push({frame, video_pts, audio_pts})) {
             graph_->set_tag(diagnostics::tag_severity::WARNING, "dropped-frame");
         }
 
@@ -704,6 +731,8 @@ struct ffmpeg_consumer : public core::frame_consumer
     std::wstring name() const override { return L"ffmpeg"; }
 
     bool has_synchronization_clock() const override { return false; }
+
+    bool supports_deterministic_sync() const override { return true; }
 
     int index() const override { return 100000 + channel_info_.index; }
 

--- a/src/modules/ffmpeg/producer/av_producer.cpp
+++ b/src/modules/ffmpeg/producer/av_producer.cpp
@@ -884,11 +884,18 @@ struct AVProducer::Impl
                 auto start    = start_.load();
                 auto duration = duration_.load();
 
-                start       = start != AV_NOPTS_VALUE ? start : 0;
-                auto end    = duration != AV_NOPTS_VALUE ? start + duration : INT64_MAX;
-                auto time   = frame.pts != AV_NOPTS_VALUE ? frame.pts + frame.duration : 0;
-                buffer_eof_ = (video_filter_.eof && audio_filter_.eof) ||
+                start         = start != AV_NOPTS_VALUE ? start : 0;
+                auto end      = duration != AV_NOPTS_VALUE ? start + duration : INT64_MAX;
+                auto time     = frame.pts != AV_NOPTS_VALUE ? frame.pts + frame.duration : 0;
+                bool prev_eof = buffer_eof_.load();
+                buffer_eof_   = (video_filter_.eof && audio_filter_.eof) ||
                               av_rescale_q(time, TIME_BASE_Q, format_tb_) >= av_rescale_q(end, TIME_BASE_Q, format_tb_);
+
+                if (!prev_eof && buffer_eof_.load()) {
+                    // Wake consumers blocked in wait_for_frame so they don't hang past EOF.
+                    boost::lock_guard<boost::mutex> lock(buffer_mutex_);
+                    buffer_cond_.notify_all();
+                }
 
                 if (buffer_eof_) {
                     if (loop_ && frame_count_ > 2) {
@@ -982,6 +989,8 @@ struct AVProducer::Impl
                 buffer_cond_.wait(buffer_lock, [&] { return buffer_.size() < buffer_capacity_; });
                 if (seek_ == AV_NOPTS_VALUE) {
                     buffer_.push_back(frame);
+                    // Wake any consumer blocked on wait_for_frame().
+                    buffer_cond_.notify_all();
                 }
             }
 
@@ -1033,6 +1042,35 @@ struct AVProducer::Impl
     {
         boost::lock_guard<boost::mutex> lock(buffer_mutex_);
         return !buffer_.empty() || frame_;
+    }
+
+    bool wait_for_frame(std::chrono::milliseconds timeout)
+    {
+        // Wait until `next_frame()` will actually deliver. Two conditions must match
+        // next_frame's underflow check (see this file's next_frame): the buffer must
+        // be non-empty, and on the first delivery after construction or a seek
+        // (frame_flush_ == true) we need at least 4 frames queued — otherwise
+        // next_frame returns an empty draw_frame and the layer falls back to
+        // prev_frame, which peeks buffer[0] without popping. That peek-then-pop
+        // pattern delivers frame 0 twice and lags every subsequent frame by one
+        // tick — invisible at wall-clock pacing but a determinism bug in render
+        // mode. `frame_` (the last delivered frame) must not satisfy this wait;
+        // once set it would turn the wait into a no-op.
+        boost::unique_lock<boost::mutex> lock(buffer_mutex_);
+        auto ready = [&] {
+            if (buffer_eof_.load()) {
+                return true;
+            }
+            if (buffer_.empty()) {
+                return false;
+            }
+            return !frame_flush_ || buffer_.size() >= 4;
+        };
+        if (ready()) {
+            return true;
+        }
+        const auto boost_timeout = boost::chrono::milliseconds(timeout.count());
+        return buffer_cond_.wait_for(lock, boost_timeout, ready);
     }
 
     core::draw_frame next_frame(const core::video_field field)
@@ -1318,6 +1356,8 @@ core::draw_frame AVProducer::next_frame(const core::video_field field) { return 
 core::draw_frame AVProducer::prev_frame(const core::video_field field) { return impl_->prev_frame(field); }
 
 bool AVProducer::is_ready() { return impl_->is_ready(); }
+
+bool AVProducer::wait_for_frame(std::chrono::milliseconds timeout) { return impl_->wait_for_frame(timeout); }
 
 AVProducer& AVProducer::seek(int64_t time)
 {

--- a/src/modules/ffmpeg/producer/av_producer.h
+++ b/src/modules/ffmpeg/producer/av_producer.h
@@ -6,6 +6,7 @@
 #include <core/monitor/monitor.h>
 #include <core/video_format.h>
 
+#include <chrono>
 #include <memory>
 #include <optional>
 #include <string>
@@ -31,6 +32,7 @@ class AVProducer
     core::draw_frame prev_frame(const core::video_field field);
     core::draw_frame next_frame(const core::video_field field);
     bool             is_ready();
+    bool             wait_for_frame(std::chrono::milliseconds timeout);
 
     AVProducer& seek(int64_t time);
     int64_t     time() const;

--- a/src/modules/ffmpeg/producer/ffmpeg_producer.cpp
+++ b/src/modules/ffmpeg/producer/ffmpeg_producer.cpp
@@ -129,6 +129,13 @@ struct ffmpeg_producer : public core::frame_producer
 
     bool is_ready() override { return producer_->is_ready(); }
 
+    bool supports_deterministic_sync() const override { return true; }
+
+    bool wait_for_frame(const core::video_field field, std::chrono::milliseconds timeout) override
+    {
+        return producer_->wait_for_frame(timeout);
+    }
+
     std::future<std::wstring> call(const std::vector<std::wstring>& params) override
     {
         std::wstring result;

--- a/src/modules/html/html.cpp
+++ b/src/modules/html/html.cpp
@@ -103,10 +103,12 @@ class renderer_application
 {
     std::vector<CefRefPtr<CefV8Context>> contexts_;
     const bool                           enable_gpu_;
+    const bool                           virtual_time_;
 
   public:
-    explicit renderer_application(const bool enable_gpu)
+    explicit renderer_application(const bool enable_gpu, const bool virtual_time)
         : enable_gpu_(enable_gpu)
+        , virtual_time_(virtual_time)
     {
     }
 
@@ -129,13 +131,17 @@ class renderer_application
 
         CefRefPtr<CefV8Value>     ret;
         CefRefPtr<CefV8Exception> exception;
-        bool                      injected = context->Eval(R"(
-            window.caspar = window.casparcg = {};
-		)",
-                                      CefString(),
-                                      1,
-                                      ret,
-                                      exception);
+        const std::string         s = R"JS(window.caspar = window.casparcg = {};(function(){
+if(window.__casparNoVideo)return;window.__casparNoVideo=1;
+var kill=function(v){try{ console.log('found video element');v.removeAttribute('src'); v.removeAttribute('autoplay'); v.removeAttribute('paused'); v.removeAttribute('preload'); }catch(e){}try{v.muted=true;}catch(e){}try{v.style.display='none';}catch(e){}};
+var mock=function(){return Promise.resolve();};
+try{var P=HTMLMediaElement.prototype;if(!P.__casparPatched){P.__casparPatched=1;P.play=mock;P.load=mock;}}catch(e){}
+var scan=function(){try{var vs=document.querySelectorAll('video');for(var i=0;i<vs.length;i++)kill(vs[i]);}catch(e){}};
+var start=function(){scan();try{window.__casparVideoGuard=new MutationObserver(function(m){for(var i=0;i<m.length;i++){var a=m[i].addedNodes;for(var j=0;j<a.length;j++){var n=a[j];if(n&&n.nodeType===1){if(n.tagName==='VIDEO'){kill(n); console.log('killing from mutationobserver');}else if(n.querySelectorAll){var q=n.querySelectorAll('video');for(var k=0;k<q.length;k++)kill(q[k]);}}}}}).observe(document.documentElement,{childList:true,subtree:true});}catch(e){}};
+if(document?.documentElement) {start();console.log('starting directly');}else window.addEventListener('pageshow',function() {start(); console.log('starting after pageshow');});
+})();)JS";
+
+        bool injected = context->Eval(s, CefString(), 1, ret, exception);
 
         if (!injected) {
             caspar_log(browser, boost::log::trivial::error, "Could not inject javascript animation code.");
@@ -187,6 +193,8 @@ class renderer_application
 #if __unix__
         if (getenv("DISPLAY") == nullptr) {
             command_line->AppendSwitchWithValue("ozone-platform", "headless");
+        } else {
+            command_line->AppendSwitchWithValue("ozone-platform", "x11");
         }
 #endif
 
@@ -196,6 +204,15 @@ class renderer_application
         command_line->AppendSwitch("use-fake-ui-for-media-stream");
         command_line->AppendSwitchWithValue("autoplay-policy", "no-user-gesture-required");
         command_line->AppendSwitchWithValue("remote-allow-origins", "*");
+
+        if (virtual_time_) {
+            // HeadlessExperimental.beginFrame needs the compositor to run all stages
+            // synchronously per BeginFrame, otherwise paints can lag behind the tick we
+            // explicitly requested (defeating deterministic rendering).
+            command_line->AppendSwitch("run-all-compositor-stages-before-draw");
+            // We drive frame production from the host; the renderer must not throttle.
+            command_line->AppendSwitch("disable-frame-rate-limit");
+        }
 
         if (process_type.empty() && !enable_gpu_) {
             // This gives more performance, but disabled gpu effects. Without it a single 1080p producer cannot be run
@@ -218,7 +235,7 @@ bool intercept_command_line(int argc, char** argv)
     CefMainArgs main_args(argc, argv);
 #endif
 
-    return CefExecuteProcess(main_args, CefRefPtr<CefApp>(new renderer_application(false)), nullptr) >= 0;
+    return CefExecuteProcess(main_args, CefRefPtr<CefApp>(new renderer_application(false, false)), nullptr) >= 0;
 }
 
 void init(const core::module_dependencies& dependencies)
@@ -248,7 +265,10 @@ void init(const core::module_dependencies& dependencies)
             CefString(&settings.cache_path).FromWString(cache_path);
         }
 
-        return CefInitialize(main_args, settings, CefRefPtr<CefApp>(new renderer_application(enable_gpu)), nullptr);
+        const bool virtual_time = env::properties().get(L"configuration.html.enable-virtual-time", false);
+
+        return CefInitialize(
+            main_args, settings, CefRefPtr<CefApp>(new renderer_application(enable_gpu, virtual_time)), nullptr);
     });
 
     if (!result) {

--- a/src/modules/html/producer/html_producer.cpp
+++ b/src/modules/html/producer/html_producer.cpp
@@ -54,9 +54,14 @@
 #pragma warning(disable : 4458)
 #include <include/cef_app.h>
 #include <include/cef_client.h>
+#include <include/cef_devtools_message_observer.h>
+#include <include/cef_registration.h>
 #include <include/cef_render_handler.h>
+#include <include/cef_values.h>
 #pragma warning(pop)
 
+#include <chrono>
+#include <condition_variable>
 #include <optional>
 #include <queue>
 #include <utility>
@@ -112,6 +117,7 @@ class html_client
     , public CefLifeSpanHandler
     , public CefLoadHandler
     , public CefDisplayHandler
+    , public CefDevToolsMessageObserver
 {
     std::wstring                        url_;
     spl::shared_ptr<diagnostics::graph> graph_;
@@ -125,6 +131,8 @@ class html_client
     spl::shared_ptr<core::frame_factory> frame_factory_;
     core::video_format_desc              format_desc_;
     bool                                 gpu_enabled_;
+    bool                                 vtc_enabled_;
+    bool                                 wait_for_fp_;
     tbb::concurrent_queue<std::wstring>  javascript_before_load_;
     std::atomic<bool>                    loaded_;
     std::atomic<bool>                    not_found_;
@@ -141,19 +149,63 @@ class html_client
     core::draw_frame   last_frame_;
     std::int_least64_t last_frame_time_;
 
-    CefRefPtr<CefBrowser> browser_;
+    CefRefPtr<CefBrowser>      browser_;
+    CefRefPtr<CefRegistration> cdp_registration_; // keeps DevTools observer alive
+
+    // ── Virtual time / external BeginFrame state ────────────────────────────
+    // Active when vtc_enabled_ is true. Drives one tick per channel pull:
+    // each wait_for_frame() advances virtual time by one frame duration and
+    // issues one HeadlessExperimental.beginFrame, then blocks until both the
+    // virtualTimeBudgetExpired event and OnPaint have been observed for that
+    // tick.
+    // ready_to_render_ flips once the page is ready for pulled ticks. In vtc mode that
+    // means both load and firstPaint have been observed (in either order) and virtual
+    // time has been paused. In non-vtc mode it's just OnLoadEnd.
+    std::atomic<bool>       first_paint_seen_{false};
+    std::atomic<bool>       ready_to_render_{false};
+    mutable std::mutex      ready_mutex_;
+    std::condition_variable ready_cv_;
+
+    std::mutex              tick_mutex_;
+    std::condition_variable tick_cv_;
+    bool                    tick_budget_expired_ = false;
+    bool                    tick_paint_received_ = false;
+
+    uint64_t frame_count_ = 0; // number of vtc ticks issued
+
+    // ── Marker-sync (TID_UI only) ───────────────────────────────────────────
+    // A unique per-tick color marker is stamped into the page's top-left corner
+    // (window.__casparMark) so OnPaint can correlate a paint buffer to the
+    // committed frame and discard stale / partially-composited paints (CEF
+    // issue #4166). These are only touched on the CEF UI thread — tick()'s
+    // dispatched lambda, the virtualTimeBudgetExpired handler and OnPaint all run
+    // there — so they need no extra locking. The marker is overwritten before the
+    // frame is queued so it never reaches the output.
+    static constexpr int MARK_W              = 6; // marker block size (device px)
+    static constexpr int MARK_H              = 6;
+    static constexpr int MARKER_TOL          = 24;        // per-channel match tolerance
+    static constexpr int SYNC_PUMP_MS        = 4;         // pacing between begin-frames (renderer breathing room)
+    static constexpr int SYNC_TIMEOUT_MS     = 250;       // wall-clock budget to get the marker-matching paint
+    uint8_t              expected_marker_[3] = {0, 0, 0}; // r,g,b expected this tick (TID_UI)
+    std::atomic<int>     sync_retries_       = 0;         // begin-frames pumped this tick (diagnostics)
+    std::atomic<int>     paints_this_tick_   = 0;         // OnPaint calls observed this tick (diagnostics)
+    bool                 force_accept_       = false;     // give-up: accept next paint regardless of marker
 
   public:
     html_client(spl::shared_ptr<core::frame_factory>       frame_factory,
                 const spl::shared_ptr<diagnostics::graph>& graph,
                 core::video_format_desc                    format_desc,
                 bool                                       gpu_enabled,
+                bool                                       vtc_enabled,
+                bool                                       wait_for_fp,
                 std::wstring                               url)
         : url_(std::move(url))
         , graph_(graph)
         , frame_factory_(std::move(frame_factory))
         , format_desc_(std::move(format_desc))
         , gpu_enabled_(gpu_enabled)
+        , vtc_enabled_(vtc_enabled)
+        , wait_for_fp_(wait_for_fp)
     {
         graph_->set_color("browser-tick-time", diagnostics::color(0.1f, 1.0f, 0.1f));
         graph_->set_color("tick-time", diagnostics::color(0.0f, 0.6f, 0.9f));
@@ -186,11 +238,54 @@ class html_client
     {
         closing_ = true;
 
+        // Wake anything blocked in wait_for_frame / tick so it can observe closing_.
+        ready_cv_.notify_all();
+        tick_cv_.notify_all();
+
         html::invoke([=] {
+            cdp_registration_ = nullptr; // unregister DevTools observer
             if (browser_ != nullptr) {
                 browser_->GetHost()->CloseBrowser(true);
             }
         });
+    }
+
+    bool supports_deterministic_sync() const { return vtc_enabled_; }
+
+    // Pull-based tick driver used by the deterministic channel.
+    // Returns true once a frame is queued and ready for receive(). Each
+    // successful call advances virtual time by one frame duration and issues
+    // exactly one BeginFrame, so the channel and the page tick in lockstep.
+    bool wait_for_frame(std::chrono::milliseconds timeout)
+    {
+        if (!vtc_enabled_) {
+            return is_ready();
+        }
+
+        const auto deadline = std::chrono::steady_clock::now() + timeout;
+
+        // Wait for first paint (which we treat as "page has produced at least
+        // one frame and is ready for ticked rendering").
+        {
+            std::unique_lock<std::mutex> lock(ready_mutex_);
+            if (!ready_cv_.wait_until(
+                    lock, deadline, [&] { return ready_to_render_.load() || closing_ || not_found_; }))
+                return false;
+            if (closing_ || not_found_)
+                return false;
+        }
+
+        // If this tick's frame is already queued (not yet popped), nothing to do.
+        // Note: we must check the queue, not is_ready() — is_ready() also reports
+        // true once last_frame_ is set, which persists after the first pop and would
+        // suppress every subsequent tick, freezing the render on frame 1.
+        {
+            std::lock_guard<std::mutex> lock(frames_mutex_);
+            if (!frames_.empty())
+                return true;
+        }
+
+        return tick(deadline);
     }
 
     bool try_pop(const core::video_field field)
@@ -221,7 +316,7 @@ class html_client
              * The hazard here is that sometimes animations will
              * start a field later than intended.
              */
-            if (field == core::video_field::a && frames_.size() == 1) {
+            if (!vtc_enabled_ && field == core::video_field::a && frames_.size() == 1) {
                 auto now_time = now();
 
                 // Make sure there has been a gap before this pop, of at least a couple of frames
@@ -333,12 +428,54 @@ class html_client
         if (closing_ || not_found_)
             return;
 
+        // Drop paints arriving before the page is ready (only when vtc or wait-for-fp
+        // is enabled). Avoids the empty initial frame being captured as the first frame.
+        if ((vtc_enabled_ || wait_for_fp_) && !ready_to_render_.load())
+            return;
+
         graph_->set_value("browser-tick-time", paint_timer_.elapsed() * format_desc_.fps * 0.5);
         paint_timer_.restart();
         CASPAR_ASSERT(CefCurrentlyOn(TID_UI));
 
         if (type != PET_VIEW)
             return;
+
+        // Marker-sync: in deterministic mode, accept a paint only if it carries THIS tick's
+        // marker (CEF #4166 — stale/partial paints show an earlier marker). Crucially this
+        // rejects leftover paints from previous ticks, so a tick can never be satisfied by an
+        // old frame (which dropped/duplicated frames and made playback choppy). tick() drives
+        // the begin-frame pumping; here we only judge and, on a match, queue the frame.
+        if (vtc_enabled_) {
+            ++paints_this_tick_;
+            const auto* buf = static_cast<const unsigned char*>(buffer);
+            int         rr = 0, gg = 0, bb = 0;
+            bool        matched = false;
+            const int   cx      = MARK_W / 2;
+            const int   cy      = MARK_H / 2;
+            if (buf != nullptr && cx < width && cy < height) {
+                const size_t o = (static_cast<size_t>(cy) * width + cx) * 4;
+                rr             = buf[o + 2];
+                gg             = buf[o + 1];
+                bb             = buf[o + 0];
+                const int dr   = rr - expected_marker_[0];
+                const int dg   = gg - expected_marker_[1];
+                const int db   = bb - expected_marker_[2];
+                matched        = dr <= MARKER_TOL && dr >= -MARKER_TOL && dg <= MARKER_TOL && dg >= -MARKER_TOL &&
+                          db <= MARKER_TOL && db >= -MARKER_TOL;
+            }
+
+            bool accept;
+            {
+                std::lock_guard<std::mutex> lock(tick_mutex_);
+                // Only once per tick, only after this tick's budget expired, only on a marker
+                // match (or a forced give-up). OnPaint is serialized on TID_UI, so the next
+                // paint sees tick_paint_received_ already set and is discarded.
+                accept = tick_budget_expired_ && !tick_paint_received_ && (matched || force_accept_);
+            }
+
+            if (!accept)
+                return; // discard stale / pre-budget / duplicate paint; tick() pumps the next
+        }
 
         core::pixel_format_desc pixel_desc(core::pixel_format::bgra);
         pixel_desc.planes.emplace_back(width, height, 4);
@@ -363,6 +500,17 @@ class html_client
 
         graph_->set_value("memcpy", test_timer_.elapsed() * format_desc_.fps * 0.5 * 5);
 
+        // Hide the corner marker: overwrite the marker block with the pixel just to its
+        // right so it never reaches the output (a few-pixel corner smear at worst).
+        if (vtc_enabled_ && width > MARK_W) {
+            for (int y = 0; y < MARK_H && y < height; ++y) {
+                char*       row = dst + static_cast<size_t>(y) * width * 4;
+                const char* nbr = row + static_cast<size_t>(MARK_W) * 4;
+                for (int x = 0; x < MARK_W; ++x)
+                    std::memcpy(row + static_cast<size_t>(x) * 4, nbr, 4);
+            }
+        }
+
         {
             std::lock_guard<std::mutex> lock(frames_mutex_);
 
@@ -375,6 +523,8 @@ class html_client
             }
             graph_->set_value("buffered-frames", (double)frames_.size() / frames_max_size_);
         }
+
+        notify_tick_paint();
     }
 
     void OnAfterCreated(CefRefPtr<CefBrowser> browser) override
@@ -382,6 +532,26 @@ class html_client
         CASPAR_ASSERT(CefCurrentlyOn(TID_UI));
 
         browser_ = std::move(browser);
+
+        if (vtc_enabled_ || wait_for_fp_) {
+            cdp_registration_ = browser_->GetHost()->AddDevToolsMessageObserver(this);
+
+            // Page.enable + lifecycle events: needed for firstPaint detection.
+            browser_->GetHost()->ExecuteDevToolsMethod(0, "Page.enable", nullptr);
+
+            auto lc = CefDictionaryValue::Create();
+            lc->SetBool("enabled", true);
+            browser_->GetHost()->ExecuteDevToolsMethod(0, "Page.setLifecycleEventsEnabled", lc);
+
+            // if (vtc_enabled_) {
+            //     // Run the video-neutralizer at document-start on every document (before any page
+            //     // script), so a <video> never enters the not-ready/playing state that stalls
+            //     // compositing. See video_neutralizer_script().
+            //     auto add = CefDictionaryValue::Create();
+            //     add->SetString("source", video_neutralizer_script());
+            //     browser_->GetHost()->ExecuteDevToolsMethod(0, "Page.addScriptToEvaluateOnNewDocument", add);
+            // }
+        }
     }
 
     void OnBeforeClose(CefRefPtr<CefBrowser> browser) override
@@ -447,6 +617,13 @@ class html_client
             std::lock_guard<std::mutex> lock(state_mutex_);
             state_ = {};
         }
+
+        // Wake anything blocked in wait_for_frame so it can observe not_found_ and bail out.
+        ready_cv_.notify_all();
+        {
+            std::lock_guard<std::mutex> lock(tick_mutex_);
+        }
+        tick_cv_.notify_all();
     }
 
     void OnLoadEnd(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, int httpStatusCode) override
@@ -456,6 +633,44 @@ class html_client
 
         loaded_ = true;
         execute_queued_javascript();
+
+        maybe_arm_ready();
+    }
+
+    // Called when either firstPaint or load has fired. Flips ready_to_render_ once
+    // the page is in a state suitable for the channel to start pulling frames. In
+    // vtc mode this also pauses the page's virtual clock so subsequent ticks own
+    // the timeline.
+    void maybe_arm_ready()
+    {
+        if (!loaded_.load())
+            return;
+        // In vtc mode the compositor only paints in response to a BeginFrame we
+        // issue from tick(), and we don't tick until ready_to_render_ is set — so
+        // gating readiness on firstPaint here would deadlock (firstPaint needs a
+        // paint needs a BeginFrame needs ready). Arm on load alone; the first
+        // tick's BeginFrame produces the first painted frame. The firstPaint gate
+        // still applies in the non-vtc wait-for-fp case, where CEF paints on its
+        // own and we only want to start once real content has been rendered.
+        if (wait_for_fp_ && !vtc_enabled_ && !first_paint_seen_.load())
+            return;
+        if (ready_to_render_.load())
+            return;
+
+        if (vtc_enabled_) {
+            CASPAR_ASSERT(CefCurrentlyOn(TID_UI));
+            // Freeze the page's virtual clock. From here, every tick() advances time by
+            // exactly one frame duration via a budgeted setVirtualTimePolicy + beginFrame.
+            auto p = CefDictionaryValue::Create();
+            p->SetString("policy", "pause");
+            browser_->GetHost()->ExecuteDevToolsMethod(0, "Emulation.setVirtualTimePolicy", p);
+        }
+
+        ready_to_render_ = true;
+        {
+            std::lock_guard<std::mutex> lock(ready_mutex_);
+        }
+        ready_cv_.notify_all();
     }
 
     bool OnProcessMessageReceived(CefRefPtr<CefBrowser>        browser,
@@ -550,6 +765,201 @@ class html_client
                std::to_wstring(format_desc_.square_height) + L" " + std::to_wstring(format_desc_.fps);
     }
 
+    // ── Virtual time / BeginFrame helpers ──────────────────────────────────
+
+    // Cumulative virtual time (µs) at the end of frame N. Computed from the
+    // rational frame duration (`duration / time_scale`) rather than a per-frame
+    // float increment so non-integer rates (NTSC) don't drift.
+    uint64_t virtual_time_us_at(uint64_t frame_n) const
+    {
+        const uint64_t num = static_cast<uint64_t>(format_desc_.duration) * 1'000'000ULL;
+        const uint64_t den = static_cast<uint64_t>(format_desc_.time_scale);
+        return den > 0 ? (frame_n * num) / den : 0;
+    }
+
+    // Advance virtual time by one frame budget; the compositing BeginFrame is
+    // issued from OnDevToolsEvent when virtualTimeBudgetExpired fires (so the clock
+    // has reached and paused at this frame's timestamp before we paint). Blocks
+    // until both that event and the resulting OnPaint are observed.
+    // Runs on the channel thread; CEF calls are dispatched to TID_UI.
+    bool tick(std::chrono::steady_clock::time_point deadline)
+    {
+        const uint64_t prev_us   = virtual_time_us_at(frame_count_);
+        const uint64_t next_us   = virtual_time_us_at(frame_count_ + 1);
+        const uint64_t budget_us = next_us - prev_us;
+
+        const double budget_ms = static_cast<double>(budget_us) / 1000.0;
+
+        ++frame_count_;
+
+        {
+            std::lock_guard<std::mutex> lock(tick_mutex_);
+            tick_budget_expired_ = false;
+            tick_paint_received_ = false;
+            force_accept_        = false;
+        }
+
+        // Per-tick marker color, well-spread so consecutive ticks differ greatly in
+        // every channel (a stale previous-tick marker can never fall inside tolerance).
+        const uint8_t mr = static_cast<uint8_t>((frame_count_ * 97 + 13) & 0xFF);
+        const uint8_t mg = static_cast<uint8_t>((frame_count_ * 149 + 71) & 0xFF);
+        const uint8_t mb = static_cast<uint8_t>((frame_count_ * 211 + 167) & 0xFF);
+
+        html::begin_invoke([this, budget_ms, mr, mg, mb] {
+            if (closing_ || browser_ == nullptr)
+                return;
+
+            // Stamp this tick's corner marker and reset the per-tick retry count.
+            // OnPaint reads the marker back to confirm the frame is the committed,
+            // fully-composited one before accepting it (CEF #4166). The marker change
+            // and this frame's animation work composite together on the BeginFrame
+            // issued after virtualTimeBudgetExpired.
+            expected_marker_[0] = mr;
+            expected_marker_[1] = mg;
+            expected_marker_[2] = mb;
+            sync_retries_       = 0;
+            paints_this_tick_   = 0;
+            {
+                // Set the marker via Runtime.evaluate on the SAME DevTools pipe as the
+                // virtual-time advance below, so it is processed first and its DOM
+                // mutation is committed by the budget's BeginMainFrame together with this
+                // frame's content. (CefFrame::ExecuteJavaScript uses a separate IPC path
+                // that races virtual time and lands the marker a frame or two late — which
+                // made every tick read a stale marker.) The expression is self-contained,
+                // so it also (re)creates the marker element if a template wiped the DOM.
+                const std::string rgb =
+                    "rgb(" + std::to_string(mr) + "," + std::to_string(mg) + "," + std::to_string(mb) + ")";
+                const std::string expr = "(function(c){var m=document.getElementById('__caspar_mark');"
+                                         "if(!m){m=document.createElement('div');m.id='__caspar_mark';"
+                                         "m.style.cssText='position:fixed;left:0;top:0;width:6px;height:6px;"
+                                         "margin:0;padding:0;border:0;z-index:2147483647;pointer-events:none';"
+                                         "document.documentElement.appendChild(m);}m.style.background=c;})('" +
+                                         rgb + "')";
+                auto ev = CefDictionaryValue::Create();
+                ev->SetString("expression", expr);
+                browser_->GetHost()->ExecuteDevToolsMethod(0, "Runtime.evaluate", ev);
+            }
+
+            // Advance the page's virtual clock by exactly one frame duration.
+            // Use pauseIfNetworkFetchesPending so an in-flight fetch defers the
+            // tick rather than letting JS observe an inconsistent clock jump.
+            // When the budget is consumed, Emulation.virtualTimeBudgetExpired fires
+            // (handled in OnDevToolsEvent) and we composite the frame from there.
+            auto vt = CefDictionaryValue::Create();
+            vt->SetString("policy", "pauseIfNetworkFetchesPending");
+            vt->SetDouble("budget", budget_ms);
+            browser_->GetHost()->ExecuteDevToolsMethod(0, "Emulation.setVirtualTimePolicy", vt);
+        });
+
+        // Wait for the budget to expire: virtual time has advanced one frame and paused,
+        // with this tick's content + marker committed.
+        {
+            std::unique_lock<std::mutex> lock(tick_mutex_);
+            if (!tick_cv_.wait_until(lock, deadline, [&] { return tick_budget_expired_ || closing_ || not_found_; }))
+                return false;
+            if (closing_ || not_found_)
+                return false;
+        }
+
+        // Pump begin-frames, paced with breathing room, until OnPaint delivers a frame
+        // carrying this tick's marker. Back-to-back begin-frames just re-deliver the same
+        // stale buffer; the renderer needs a few ms to composite the freshly-committed frame
+        // (CEF #4166 — the matching paint arrived ~6ms after the budget). Pacing is wall-clock
+        // only — virtual time stays paused — so the captured frame is deterministic; only the
+        // number of discarded paints varies run to run.
+        auto sync_deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(SYNC_TIMEOUT_MS);
+        if (sync_deadline > deadline)
+            sync_deadline = deadline;
+
+        while (std::chrono::steady_clock::now() < deadline) {
+            {
+                std::unique_lock<std::mutex> lock(tick_mutex_);
+                if (tick_paint_received_)
+                    return !closing_ && !not_found_;
+                if (closing_ || not_found_)
+                    return false;
+            }
+
+            if (std::chrono::steady_clock::now() >= sync_deadline && !force_accept_) {
+                std::lock_guard<std::mutex> lock(tick_mutex_);
+                force_accept_ = true;
+            }
+
+            html::begin_invoke([this] {
+                if (closing_ || browser_ == nullptr)
+                    return;
+                ++sync_retries_;
+                browser_->GetHost()->Invalidate(PET_VIEW);
+                browser_->GetHost()->SendExternalBeginFrame();
+            });
+
+            std::unique_lock<std::mutex> lock(tick_mutex_);
+            tick_cv_.wait_for(lock, std::chrono::milliseconds(SYNC_PUMP_MS), [&] {
+                return tick_paint_received_ || closing_ || not_found_;
+            });
+        }
+
+        CASPAR_LOG(warning) << print() << L" [vtc] tick " << frame_count_ << L" gave up at deadline (begin-frames="
+                            << sync_retries_.load() << L", paints=" << paints_this_tick_.load() << L")";
+        return false;
+    }
+
+    void notify_tick_paint()
+    {
+        if (!vtc_enabled_)
+            return;
+
+        {
+            std::lock_guard<std::mutex> lock(tick_mutex_);
+            tick_paint_received_ = true;
+        }
+        tick_cv_.notify_all();
+    }
+
+    // ── CefDevToolsMessageObserver ─────────────────────────────────────────
+
+    void OnDevToolsEvent(CefRefPtr<CefBrowser> browser,
+                         const CefString&      method,
+                         const void*           message,
+                         size_t                message_size) override
+    {
+        CASPAR_ASSERT(CefCurrentlyOn(TID_UI));
+
+        if (method == "Page.lifecycleEvent") {
+            // Payload: {"frameId":"...","loaderId":"...","name":"firstPaint","timestamp":...}
+            const std::string payload(static_cast<const char*>(message), message_size);
+            if (payload.find("\"firstPaint\"") != std::string::npos) {
+                CASPAR_LOG(info) << print() << L" CDP: firstPaint";
+                first_paint_seen_ = true;
+                maybe_arm_ready();
+            }
+        } else if (method == "Emulation.virtualTimeBudgetExpired") {
+            // Virtual time reached this frame's timestamp and is paused; this tick's content
+            // and marker are committed. tick() now pumps begin-frames (paced) until the
+            // marker-matching paint arrives. We deliberately do NOT composite from here: a
+            // begin-frame issued here could outlive the tick and satisfy the *next* tick with
+            // a stale frame, which dropped/duplicated frames and made playback choppy.
+            {
+                std::lock_guard<std::mutex> lock(tick_mutex_);
+                tick_budget_expired_ = true;
+            }
+
+            tick_cv_.notify_all();
+        }
+    }
+
+    void OnDevToolsMethodResult(CefRefPtr<CefBrowser> browser,
+                                int                   message_id,
+                                bool                  success,
+                                const void*           message,
+                                size_t                message_size) override
+    {
+        if (!success) {
+            const std::string payload(static_cast<const char*>(message), message_size);
+            CASPAR_LOG(warning) << print() << L" CDP method failed: " << payload;
+        }
+    }
+
     IMPLEMENT_REFCOUNTING(html_client);
 };
 
@@ -558,6 +968,7 @@ class html_producer : public core::frame_producer
     core::video_format_desc             format_desc_;
     const std::wstring                  url_;
     spl::shared_ptr<diagnostics::graph> graph_;
+    bool                                vtc_enabled_ = false;
 
     CefRefPtr<html_client> client_;
 
@@ -569,14 +980,19 @@ class html_producer : public core::frame_producer
         , url_(url)
     {
         html::invoke([&] {
-            const bool enable_gpu = env::properties().get(L"configuration.html.enable-gpu", false);
+            const bool enable_gpu  = env::properties().get(L"configuration.html.enable-gpu", false);
+            const bool vtc         = env::properties().get(L"configuration.html.enable-virtual-time", false);
+            const bool wait_for_fp = env::properties().get(L"configuration.html.wait-for-fp", false) || vtc;
 
-            client_ = new html_client(frame_factory, graph_, format_desc, enable_gpu, url_);
+            vtc_enabled_ = vtc;
+
+            client_ = new html_client(frame_factory, graph_, format_desc, enable_gpu, vtc, wait_for_fp, url_);
 
             CefWindowInfo window_info;
             window_info.bounds.width                 = format_desc.square_width;
             window_info.bounds.height                = format_desc.square_height;
             window_info.windowless_rendering_enabled = true;
+            window_info.external_begin_frame_enabled = vtc;
 
             CefBrowserSettings browser_settings;
             browser_settings.webgl = enable_gpu ? cef_state_t::STATE_ENABLED : cef_state_t::STATE_DISABLED;
@@ -611,6 +1027,16 @@ class html_producer : public core::frame_producer
     {
         if (client_ != nullptr) {
             return client_->is_ready();
+        }
+        return false;
+    }
+
+    bool supports_deterministic_sync() const override { return vtc_enabled_; }
+
+    bool wait_for_frame(const core::video_field field, std::chrono::milliseconds timeout) override
+    {
+        if (client_ != nullptr) {
+            return client_->wait_for_frame(timeout);
         }
         return false;
     }
@@ -699,5 +1125,4 @@ spl::shared_ptr<core::frame_producer> create_producer(const core::frame_producer
 {
     return create_cg_producer(dependencies, params);
 }
-
 }} // namespace caspar::html

--- a/src/modules/image/producer/image_producer.cpp
+++ b/src/modules/image/producer/image_producer.cpp
@@ -91,6 +91,7 @@ struct image_producer : public core::frame_producer
     core::draw_frame first_frame(const core::video_field field) override { return frame_; }
 
     bool is_ready() override { return true; }
+    bool supports_deterministic_sync() const override { return true; }
 
     core::draw_frame receive_impl(const core::video_field field, int nb_samples) override { return frame_; }
 

--- a/src/modules/image/producer/image_scroll_producer.cpp
+++ b/src/modules/image/producer/image_scroll_producer.cpp
@@ -398,6 +398,7 @@ struct image_scroll_producer : public core::frame_producer
     core::monitor::state state() const override { return state_; }
 
     bool is_ready() override { return !frames_.empty(); }
+    bool supports_deterministic_sync() const override { return true; }
 };
 
 spl::shared_ptr<core::frame_producer> create_scroll_producer(const core::frame_producer_dependencies& dependencies,

--- a/src/protocol/CMakeLists.txt
+++ b/src/protocol/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SOURCES
 		amcp/amcp_command_repository.cpp
 		amcp/amcp_args.cpp
 		amcp/amcp_command_repository_wrapper.cpp
+		amcp/virtual_channel_registry.cpp
 
 		osc/oscpack/OscOutboundPacketStream.cpp
 		osc/oscpack/OscPrintReceivedElements.cpp
@@ -34,6 +35,7 @@ set(HEADERS
 		amcp/amcp_shared.h
 		amcp/amcp_args.h
 		amcp/amcp_command_context.h
+		amcp/virtual_channel_registry.h
 
 		osc/oscpack/MessageMappingOscPacketListener.h
 		osc/oscpack/OscException.h

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -61,6 +61,7 @@
 #include <algorithm>
 #include <fstream>
 #include <future>
+#include <list>
 #include <memory>
 
 #include <boost/algorithm/string.hpp>
@@ -1733,6 +1734,227 @@ std::wstring osc_unsubscribe_command(command_context& ctx)
     return L"202 OSC UNSUBSCRIBE OK\r\n";
 }
 
+// Per-connection state for an in-progress SCHEDULE BEGIN / ... / COMMIT session.
+// Bound to the client connection under the key L"schedule-session". When the connection
+// closes before COMMIT (or never reaches COMMIT), the dtor destroys the virtual channel
+// so a half-prepared render does not leak.
+struct schedule_session
+{
+    std::weak_ptr<virtual_channel_registry> registry;
+    int                                     virtual_channel_id = 0;
+    int                                     consumer_index     = 0;
+    std::shared_ptr<core::frame_consumer>   consumer;
+    std::optional<uint64_t>                 end_frame;
+    std::atomic<bool>                       committed{false};
+
+    ~schedule_session()
+    {
+        if (committed.load())
+            return; // render owns itself from here on
+        if (auto r = registry.lock())
+            r->destroy(virtual_channel_id);
+    }
+};
+
+static std::shared_ptr<schedule_session> get_schedule_session(const command_context& ctx)
+{
+    return std::static_pointer_cast<schedule_session>(
+        ctx.client->find_lifecycle_bound_object(L"schedule-session"));
+}
+
+// Rewrite the bare `$` token to `$<id>` and `$-N` to `$<id>-N` so the parser's
+// $<id>[-<layer>] handling can resolve them. Explicit `$<digits>...` is left alone.
+static void resolve_session_dollar(std::list<std::wstring>& tokens, int session_id)
+{
+    const std::wstring id_str = std::to_wstring(session_id);
+    for (auto& tok : tokens) {
+        if (tok == L"$") {
+            tok = L"$" + id_str;
+        } else if (tok.size() >= 2 && tok[0] == L'$' && tok[1] == L'-') {
+            tok = L"$" + id_str + tok.substr(1);
+        }
+    }
+}
+
+std::wstring schedule_begin_command(command_context& ctx)
+{
+    if (get_schedule_session(ctx))
+        CASPAR_THROW_EXCEPTION(
+            user_error() << msg_info(L"SCHEDULE BEGIN: a session is already in progress on this connection"));
+
+    // Locate the ADD marker that separates channel metadata from the consumer spec.
+    auto add_it = std::find_if(
+        ctx.parameters.begin(), ctx.parameters.end(), [](const std::wstring& s) { return boost::iequals(s, L"ADD"); });
+    if (add_it == ctx.parameters.end())
+        CASPAR_THROW_EXCEPTION(user_error() << msg_info(L"SCHEDULE BEGIN: missing 'ADD <consumer-spec>'"));
+    if (add_it == ctx.parameters.begin())
+        CASPAR_THROW_EXCEPTION(user_error() << msg_info(L"SCHEDULE BEGIN: missing <format>"));
+
+    // SCHEDULE BEGIN <format> [color_space] [bit_depth] ADD <consumer-spec>
+    // The optional color_space (bt709|bt2020) and bit_depth (8|16) can appear in any order
+    // between <format> and ADD.
+    const std::wstring& format_str = ctx.parameters.front();
+    auto                format     = ctx.static_context->format_repository.find(format_str);
+    if (format.format == core::video_format::invalid)
+        CASPAR_THROW_EXCEPTION(user_error() << msg_info(L"SCHEDULE BEGIN: invalid video format: " + format_str));
+
+    core::color_space cs    = core::color_space::bt709;
+    common::bit_depth depth = common::bit_depth::bit8;
+    for (auto it = ctx.parameters.begin() + 1; it != add_it; ++it) {
+        const std::wstring tok = boost::to_lower_copy(*it);
+        if (tok == L"bt709")
+            cs = core::color_space::bt709;
+        else if (tok == L"bt2020")
+            cs = core::color_space::bt2020;
+        else if (tok == L"8")
+            depth = common::bit_depth::bit8;
+        else if (tok == L"16")
+            depth = common::bit_depth::bit16;
+        else
+            CASPAR_THROW_EXCEPTION(
+                user_error() << msg_info(L"SCHEDULE BEGIN: unexpected token (expected bt709|bt2020|8|16): " + *it));
+    }
+
+    std::vector<std::wstring> consumer_params(add_it + 1, ctx.parameters.end());
+    if (consumer_params.empty())
+        CASPAR_THROW_EXCEPTION(user_error() << msg_info(L"SCHEDULE BEGIN: missing consumer-spec after ADD"));
+
+    auto registry   = ctx.static_context->virtual_channels;
+    int  virtual_id = registry->create(format, cs, depth);
+
+    auto session                = std::make_shared<schedule_session>();
+    session->registry           = std::weak_ptr<virtual_channel_registry>(registry);
+    session->virtual_channel_id = virtual_id;
+    try {
+        auto                                              channel      = registry->get(virtual_id);
+        std::vector<spl::shared_ptr<core::video_channel>> all_channels = get_channels(ctx);
+        all_channels.push_back(spl::make_shared_ptr(channel.raw_channel));
+        auto consumer = ctx.static_context->consumer_registry->create_consumer(
+            consumer_params,
+            ctx.static_context->format_repository,
+            all_channels,
+            channel.raw_channel->get_consumer_channel_info());
+        if (!consumer->supports_deterministic_sync()) {
+            CASPAR_THROW_EXCEPTION(
+                user_error() << msg_info(L"SCHEDULE BEGIN: consumer does not support deterministic sync: " +
+                                         consumer->print()));
+        }
+        session->consumer       = consumer;
+        session->consumer_index = consumer->index();
+    } catch (...) {
+        registry->destroy(virtual_id);
+        throw;
+    }
+
+    ctx.client->add_lifecycle_bound_object(L"schedule-session", session);
+
+    return L"201 SCHEDULE BEGIN OK\r\n$" + std::to_wstring(virtual_id) + L"\r\n";
+}
+
+std::wstring schedule_frame_command(command_context& ctx)
+{
+    auto session = get_schedule_session(ctx);
+    if (!session)
+        CASPAR_THROW_EXCEPTION(user_error() << msg_info(L"SCHEDULE FRAME: no SCHEDULE BEGIN in progress"));
+    if (session->committed.load())
+        CASPAR_THROW_EXCEPTION(user_error() << msg_info(L"SCHEDULE FRAME: timeline is already committed"));
+
+    uint64_t frame_number = boost::lexical_cast<uint64_t>(ctx.parameters.at(0));
+
+    std::list<std::wstring> inner_tokens(ctx.parameters.begin() + 1, ctx.parameters.end());
+    if (inner_tokens.empty())
+        CASPAR_THROW_EXCEPTION(user_error() << msg_info(L"SCHEDULE FRAME requires an inner command"));
+
+    resolve_session_dollar(inner_tokens, session->virtual_channel_id);
+
+    auto inner_cmd = ctx.static_context->parser->parse_command(ctx.client, inner_tokens, L"");
+    if (!inner_cmd)
+        CASPAR_THROW_EXCEPTION(user_error() << msg_info(L"SCHEDULE FRAME: failed to parse inner command"));
+
+    auto channel    = ctx.static_context->virtual_channels->get(session->virtual_channel_id);
+    auto channels   = ctx.channels;
+    auto inner_name = inner_cmd->name();
+
+    channel.raw_channel->schedule_at(frame_number, [inner_cmd, channels, frame_number, inner_name]() {
+        try {
+            inner_cmd->Execute(channels).get();
+            CASPAR_LOG(debug) << L"Scheduled command applied at frame " << frame_number << L": " << inner_name;
+        } catch (...) {
+            CASPAR_LOG_CURRENT_EXCEPTION();
+            CASPAR_LOG(error) << L"Scheduled command failed at frame " << frame_number << L": " << inner_name;
+        }
+    });
+
+    return L"202 SCHEDULE FRAME OK\r\n";
+}
+
+std::wstring schedule_end_command(command_context& ctx)
+{
+    auto session = get_schedule_session(ctx);
+    if (!session)
+        CASPAR_THROW_EXCEPTION(user_error() << msg_info(L"SCHEDULE END: no SCHEDULE BEGIN in progress"));
+    if (session->committed.load())
+        CASPAR_THROW_EXCEPTION(user_error() << msg_info(L"SCHEDULE END: timeline is already committed"));
+
+    uint64_t end_frame = boost::lexical_cast<uint64_t>(ctx.parameters.at(0));
+    session->end_frame = end_frame;
+
+    return L"202 SCHEDULE END OK\r\n";
+}
+
+std::wstring schedule_commit_command(command_context& ctx)
+{
+    auto session = get_schedule_session(ctx);
+    if (!session)
+        CASPAR_THROW_EXCEPTION(user_error() << msg_info(L"SCHEDULE COMMIT: no SCHEDULE BEGIN in progress"));
+    if (session->committed.load())
+        CASPAR_THROW_EXCEPTION(user_error() << msg_info(L"SCHEDULE COMMIT: timeline is already committed"));
+    if (!session->end_frame)
+        CASPAR_THROW_EXCEPTION(user_error() << msg_info(L"SCHEDULE COMMIT: send SCHEDULE END <frame> before COMMIT"));
+
+    auto     registry     = ctx.static_context->virtual_channels;
+    auto     channel      = registry->get(session->virtual_channel_id);
+    auto     raw_channel  = channel.raw_channel;
+    int      virtual_id   = session->virtual_channel_id;
+    int      consumer_idx = session->consumer_index;
+    auto     consumer     = spl::make_shared_ptr(session->consumer);
+    uint64_t end_frame    = *session->end_frame;
+
+    // Schedule the teardown action at end_frame: remove the consumer (which pauses the
+    // channel via the on-consumers-changed CV) and then destroy the virtual channel from
+    // a detached thread so ~video_channel does not self-join the channel thread it runs on.
+    std::weak_ptr<virtual_channel_registry> registry_weak = registry;
+    raw_channel->schedule_at(end_frame, [raw_channel, consumer_idx, virtual_id, end_frame, registry_weak]() {
+        const bool removed = raw_channel->output().remove(consumer_idx);
+        CASPAR_LOG(info) << L"SCHEDULE END fired at frame " << end_frame << L" on virtual channel $"
+                         << virtual_id << L"; consumer index " << consumer_idx
+                         << L" removed=" << (removed ? L"true" : L"false");
+        std::thread([virtual_id, registry_weak]() {
+            if (auto r = registry_weak.lock())
+                r->destroy(virtual_id);
+        }).detach();
+    });
+
+    // Attaching the consumer is the trigger that lifts the deterministic pause and starts
+    // ticking from frame 1. If it throws synchronously (e.g. a sanity check), tear down
+    // the half-built channel and clear the session so the user can immediately retry.
+    try {
+        raw_channel->output().add(consumer_idx, consumer);
+    } catch (...) {
+        registry->destroy(virtual_id);
+        ctx.client->remove_lifecycle_bound_object(L"schedule-session");
+        throw;
+    }
+
+    // Render is launched and owns itself from here on. Mark committed so the connection-
+    // close path leaves the running render alone, then unbind the session from the
+    // connection so a fresh SCHEDULE BEGIN on the same connection works immediately.
+    session->committed.store(true);
+    ctx.client->remove_lifecycle_bound_object(L"schedule-session");
+
+    return L"202 SCHEDULE COMMIT OK\r\n";
+}
+
 void register_commands(std::shared_ptr<amcp_command_repository_wrapper>& repo)
 {
     repo->register_channel_command(L"Basic Commands", L"LOADBG", loadbg_command, 1);
@@ -1813,5 +2035,10 @@ void register_commands(std::shared_ptr<amcp_command_repository_wrapper>& repo)
 
     repo->register_command(L"Query Commands", L"OSC SUBSCRIBE", osc_subscribe_command, 1);
     repo->register_command(L"Query Commands", L"OSC UNSUBSCRIBE", osc_unsubscribe_command, 1);
+
+    repo->register_command(L"Schedule Commands", L"SCHEDULE BEGIN", schedule_begin_command, 3);
+    repo->register_command(L"Schedule Commands", L"SCHEDULE FRAME", schedule_frame_command, 2);
+    repo->register_command(L"Schedule Commands", L"SCHEDULE END", schedule_end_command, 1);
+    repo->register_command(L"Schedule Commands", L"SCHEDULE COMMIT", schedule_commit_command, 0);
 }
 }}} // namespace caspar::protocol::amcp

--- a/src/protocol/amcp/AMCPCommandsImpl.cpp
+++ b/src/protocol/amcp/AMCPCommandsImpl.cpp
@@ -1745,12 +1745,13 @@ struct schedule_session
     int                                     consumer_index     = 0;
     std::shared_ptr<core::frame_consumer>   consumer;
     std::optional<uint64_t>                 end_frame;
+    std::optional<uint64_t>                 highest_scheduled_frame; // largest frame given to SCHEDULE FRAME
     std::atomic<bool>                       committed{false};
 
     ~schedule_session()
     {
         if (committed.load())
-            return; // render owns itself from here on
+            return; // render owns itself (committed) or teardown was taken over (cancel/replace)
         if (auto r = registry.lock())
             r->destroy(virtual_channel_id);
     }
@@ -1760,6 +1761,40 @@ static std::shared_ptr<schedule_session> get_schedule_session(const command_cont
 {
     return std::static_pointer_cast<schedule_session>(
         ctx.client->find_lifecycle_bound_object(L"schedule-session"));
+}
+
+// Destroy a virtual channel off the AMCP thread. ~video_channel joins the channel's tick
+// thread, which (for a running render) can be blocked up to the deterministic stall timeout
+// inside wait_for_frame; doing the join on the AMCP thread would stall the client connection.
+static void destroy_channel_async(std::shared_ptr<virtual_channel_registry> registry, int id)
+{
+    std::weak_ptr<virtual_channel_registry> registry_weak = std::move(registry);
+    std::thread([registry_weak, id]() {
+        if (auto r = registry_weak.lock())
+            r->destroy(id);
+    }).detach();
+}
+
+// Abort an in-progress (pre-commit) session: suppress the session dtor's synchronous destroy,
+// unbind it from the connection so a fresh SCHEDULE BEGIN works immediately, and tear the
+// channel down off-thread. Used by SCHEDULE CANCEL and SCHEDULE BEGIN NEW.
+static void abort_schedule_session(command_context& ctx, const std::shared_ptr<schedule_session>& session)
+{
+    session->committed.store(true); // stop the dtor (below) from also destroying the channel
+    ctx.client->remove_lifecycle_bound_object(L"schedule-session");
+    if (auto r = session->registry.lock())
+        destroy_channel_async(r, session->virtual_channel_id);
+}
+
+// Parse a non-negative frame number, throwing a clear user_error (rather than a raw
+// bad_lexical_cast) for non-numeric / negative input.
+static uint64_t parse_frame_number(const std::wstring& token, const std::wstring& cmd)
+{
+    try {
+        return boost::lexical_cast<uint64_t>(token);
+    } catch (...) {
+    }
+    CASPAR_THROW_EXCEPTION(user_error() << msg_info(cmd + L": invalid frame number: '" + token + L"'"));
 }
 
 // Rewrite the bare `$` token to `$<id>` and `$-N` to `$<id>-N` so the parser's
@@ -1778,9 +1813,21 @@ static void resolve_session_dollar(std::list<std::wstring>& tokens, int session_
 
 std::wstring schedule_begin_command(command_context& ctx)
 {
-    if (get_schedule_session(ctx))
-        CASPAR_THROW_EXCEPTION(
-            user_error() << msg_info(L"SCHEDULE BEGIN: a session is already in progress on this connection"));
+    // Optional leading NEW keyword: discard any in-progress (pre-commit) session on this
+    // connection before starting a fresh one — a one-shot "clean the slate".
+    bool replace_existing = false;
+    if (!ctx.parameters.empty() && boost::iequals(ctx.parameters.front(), L"NEW")) {
+        replace_existing = true;
+        ctx.parameters.erase(ctx.parameters.begin());
+    }
+
+    if (auto existing = get_schedule_session(ctx)) {
+        if (!replace_existing)
+            CASPAR_THROW_EXCEPTION(user_error() << msg_info(
+                L"SCHEDULE BEGIN: a session is already in progress on this connection (use SCHEDULE BEGIN NEW ... "
+                L"to replace it, or SCHEDULE CANCEL)"));
+        abort_schedule_session(ctx, existing);
+    }
 
     // Locate the ADD marker that separates channel metadata from the consumer spec.
     auto add_it = std::find_if(
@@ -1859,7 +1906,14 @@ std::wstring schedule_frame_command(command_context& ctx)
     if (session->committed.load())
         CASPAR_THROW_EXCEPTION(user_error() << msg_info(L"SCHEDULE FRAME: timeline is already committed"));
 
-    uint64_t frame_number = boost::lexical_cast<uint64_t>(ctx.parameters.at(0));
+    // Frame 0 is valid: frame_counter_ starts at 1 and the channel drains actions with
+    // key <= frame_counter_, so a frame-0 command is applied before the first rendered frame.
+    uint64_t frame_number = parse_frame_number(ctx.parameters.at(0), L"SCHEDULE FRAME");
+    if (session->end_frame && frame_number >= *session->end_frame)
+        CASPAR_THROW_EXCEPTION(user_error()
+                               << msg_info(L"SCHEDULE FRAME: frame " + std::to_wstring(frame_number) +
+                                           L" is at or after END frame " + std::to_wstring(*session->end_frame) +
+                                           L" and would never render"));
 
     std::list<std::wstring> inner_tokens(ctx.parameters.begin() + 1, ctx.parameters.end());
     if (inner_tokens.empty())
@@ -1885,8 +1939,12 @@ std::wstring schedule_frame_command(command_context& ctx)
         }
     });
 
+    session->highest_scheduled_frame = std::max(session->highest_scheduled_frame.value_or(0), frame_number);
+
     return L"202 SCHEDULE FRAME OK\r\n";
 }
+
+std::wstring schedule_commit_command(command_context& ctx); // defined below; SCHEDULE END [COMMIT] chains into it
 
 std::wstring schedule_end_command(command_context& ctx)
 {
@@ -1896,8 +1954,31 @@ std::wstring schedule_end_command(command_context& ctx)
     if (session->committed.load())
         CASPAR_THROW_EXCEPTION(user_error() << msg_info(L"SCHEDULE END: timeline is already committed"));
 
-    uint64_t end_frame = boost::lexical_cast<uint64_t>(ctx.parameters.at(0));
+    uint64_t end_frame = parse_frame_number(ctx.parameters.at(0), L"SCHEDULE END");
+    if (end_frame < 1)
+        CASPAR_THROW_EXCEPTION(user_error() << msg_info(L"SCHEDULE END: end frame must be >= 1"));
+    // END is exclusive (frames 1..end-1 render), so it must be strictly past the last scheduled
+    // frame or that command would never be rendered.
+    if (session->highest_scheduled_frame && end_frame <= *session->highest_scheduled_frame)
+        CASPAR_THROW_EXCEPTION(user_error()
+                               << msg_info(L"SCHEDULE END: end frame " + std::to_wstring(end_frame) +
+                                           L" must be greater than the last scheduled frame " +
+                                           std::to_wstring(*session->highest_scheduled_frame)));
+
+    // Optional trailing COMMIT: end and commit the timeline in one command.
+    bool commit_now = false;
+    if (ctx.parameters.size() > 1) {
+        if (boost::iequals(ctx.parameters.at(1), L"COMMIT"))
+            commit_now = true;
+        else
+            CASPAR_THROW_EXCEPTION(user_error() << msg_info(
+                L"SCHEDULE END: unexpected token after frame (expected COMMIT): " + ctx.parameters.at(1)));
+    }
+
     session->end_frame = end_frame;
+
+    if (commit_now)
+        return schedule_commit_command(ctx);
 
     return L"202 SCHEDULE END OK\r\n";
 }
@@ -1924,11 +2005,20 @@ std::wstring schedule_commit_command(command_context& ctx)
     // channel via the on-consumers-changed CV) and then destroy the virtual channel from
     // a detached thread so ~video_channel does not self-join the channel thread it runs on.
     std::weak_ptr<virtual_channel_registry> registry_weak = registry;
-    raw_channel->schedule_at(end_frame, [raw_channel, consumer_idx, virtual_id, end_frame, registry_weak]() {
-        const bool removed = raw_channel->output().remove(consumer_idx);
-        CASPAR_LOG(info) << L"SCHEDULE END fired at frame " << end_frame << L" on virtual channel $"
-                         << virtual_id << L"; consumer index " << consumer_idx
-                         << L" removed=" << (removed ? L"true" : L"false");
+    // Capture the channel WEAKLY: this lambda is drained and destroyed on the channel's own
+    // thread, so a captured strong ref would be dropped here and could be the last one —
+    // making ~video_channel self-join its own thread (std::system_error -> terminate, the
+    // crash we hit on teardown). Take a temporary strong ref only to remove the consumer,
+    // release it, then destroy the channel from a detached thread where self-join can't occur.
+    std::weak_ptr<core::video_channel> channel_weak = raw_channel;
+    raw_channel->schedule_at(end_frame, [channel_weak, consumer_idx, virtual_id, end_frame, registry_weak]() {
+        if (auto rc = channel_weak.lock()) {
+            const bool removed = rc->output().remove(consumer_idx);
+            CASPAR_LOG(info) << L"SCHEDULE END fired at frame " << end_frame << L" on virtual channel $" << virtual_id
+                             << L"; consumer index " << consumer_idx << L" removed=" << (removed ? L"true" : L"false");
+        }
+        // No strong ref to the channel is held on this (channel) thread now, so destroying it
+        // from the detached thread below releases the last ref off-thread.
         std::thread([virtual_id, registry_weak]() {
             if (auto r = registry_weak.lock())
                 r->destroy(virtual_id);
@@ -1953,6 +2043,75 @@ std::wstring schedule_commit_command(command_context& ctx)
     ctx.client->remove_lifecycle_bound_object(L"schedule-session");
 
     return L"202 SCHEDULE COMMIT OK\r\n";
+}
+
+// SCHEDULE CANCEL [$<id>]
+//   no argument  → abort this connection's in-progress (pre-commit) session: a clean slate so a
+//                  fresh SCHEDULE BEGIN works immediately.
+//   $<id> / <id> → abort any virtual channel by id, including a committed/running render, so a
+//                  hung or failed render can be cleaned up without restarting the server.
+// The teardown always runs off the AMCP thread (a running render may be blocked in wait_for_frame).
+std::wstring schedule_cancel_command(command_context& ctx)
+{
+    auto session  = get_schedule_session(ctx);
+    auto registry = ctx.static_context->virtual_channels;
+
+    std::optional<int> target_id;
+    if (!ctx.parameters.empty()) {
+        std::wstring tok = ctx.parameters.at(0);
+        if (!tok.empty() && tok[0] == L'$')
+            tok = tok.substr(1);
+        try {
+            target_id = boost::lexical_cast<int>(tok);
+        } catch (...) {
+            CASPAR_THROW_EXCEPTION(user_error()
+                                   << msg_info(L"SCHEDULE CANCEL: invalid channel id: '" + ctx.parameters.at(0) + L"'"));
+        }
+    }
+
+    // No id: cancel this connection's in-progress session.
+    if (!target_id) {
+        if (!session)
+            CASPAR_THROW_EXCEPTION(user_error() << msg_info(
+                L"SCHEDULE CANCEL: no SCHEDULE BEGIN in progress on this connection (pass $<id> to cancel a "
+                L"running render)"));
+        abort_schedule_session(ctx, session);
+        return L"202 SCHEDULE CANCEL OK\r\n";
+    }
+
+    // Explicit id that happens to be this connection's own (pre-commit) session: abort + unbind.
+    if (session && *target_id == session->virtual_channel_id) {
+        abort_schedule_session(ctx, session);
+        return L"202 SCHEDULE CANCEL OK\r\n";
+    }
+
+    // Otherwise a committed/running render owned by the registry.
+    if (!registry->try_get(*target_id).raw_channel)
+        CASPAR_THROW_EXCEPTION(user_error()
+                               << msg_info(L"SCHEDULE CANCEL: no virtual channel $" + std::to_wstring(*target_id)));
+
+    destroy_channel_async(registry, *target_id);
+    return L"202 SCHEDULE CANCEL OK\r\n";
+}
+
+// SCHEDULE LIST — one line per live virtual channel:
+//   $<id> <format> <COMMITTED|UNCOMMITTED> frame <current-frame>
+// A channel is COMMITTED once SCHEDULE COMMIT attached its consumer (the consumer is created at
+// BEGIN but only added at COMMIT), so a consumer being present is the committed signal. Finished
+// renders are gone (the channel is destroyed at its end frame), so they do not appear.
+std::wstring schedule_list_command(command_context& ctx)
+{
+    auto channels = ctx.static_context->virtual_channels->list();
+
+    std::wstringstream out;
+    out << L"200 SCHEDULE LIST OK\r\n";
+    for (auto& [id, ch] : channels) {
+        const bool committed = ch->output().consumer_count() > 0;
+        out << L"$" << id << L" " << ch->stage()->video_format_desc().name << L" "
+            << (committed ? L"COMMITTED" : L"UNCOMMITTED") << L" frame " << ch->frame_number() << L"\r\n";
+    }
+    out << L"\r\n";
+    return out.str();
 }
 
 void register_commands(std::shared_ptr<amcp_command_repository_wrapper>& repo)
@@ -2040,5 +2199,7 @@ void register_commands(std::shared_ptr<amcp_command_repository_wrapper>& repo)
     repo->register_command(L"Schedule Commands", L"SCHEDULE FRAME", schedule_frame_command, 2);
     repo->register_command(L"Schedule Commands", L"SCHEDULE END", schedule_end_command, 1);
     repo->register_command(L"Schedule Commands", L"SCHEDULE COMMIT", schedule_commit_command, 0);
+    repo->register_command(L"Schedule Commands", L"SCHEDULE CANCEL", schedule_cancel_command, 0);
+    repo->register_command(L"Schedule Commands", L"SCHEDULE LIST", schedule_list_command, 0);
 }
 }}} // namespace caspar::protocol::amcp

--- a/src/protocol/amcp/amcp_command_context.h
+++ b/src/protocol/amcp/amcp_command_context.h
@@ -24,6 +24,7 @@
 #include "../util/ClientInfo.h"
 #include "amcp_command_repository.h"
 #include "amcp_shared.h"
+#include "virtual_channel_registry.h"
 #include <accelerator/accelerator.h>
 #include <future>
 #include <utility>
@@ -41,6 +42,7 @@ struct amcp_command_static_context
     const spl::shared_ptr<const core::frame_producer_registry> producer_registry;
     const spl::shared_ptr<const core::frame_consumer_registry> consumer_registry;
     const std::shared_ptr<amcp_command_repository>             parser;
+    const std::shared_ptr<virtual_channel_registry>            virtual_channels;
     std::function<void(bool)>                                  shutdown_server_now;
     const std::string                                          proxy_host;
     const std::string                                          proxy_port;
@@ -52,6 +54,7 @@ struct amcp_command_static_context
                                 const spl::shared_ptr<const core::frame_producer_registry>& producer_registry,
                                 const spl::shared_ptr<const core::frame_consumer_registry>& consumer_registry,
                                 std::shared_ptr<amcp_command_repository>                    parser,
+                                std::shared_ptr<virtual_channel_registry>                   virtual_channels,
                                 std::function<void(bool)>                                   shutdown_server_now,
                                 std::string                                                 proxy_host,
                                 std::string                                                 proxy_port,
@@ -62,6 +65,7 @@ struct amcp_command_static_context
         , producer_registry(producer_registry)
         , consumer_registry(consumer_registry)
         , parser(std::move(parser))
+        , virtual_channels(std::move(virtual_channels))
         , shutdown_server_now(std::move(shutdown_server_now))
         , proxy_host(std::move(proxy_host))
         , proxy_port(std::move(proxy_port))

--- a/src/protocol/amcp/amcp_command_repository.cpp
+++ b/src/protocol/amcp/amcp_command_repository.cpp
@@ -36,12 +36,14 @@ AMCPCommand::ptr_type make_cmd(amcp_command_func        func,
                                const std::wstring&      name,
                                const std::wstring&      id,
                                IO::ClientInfoPtr        client,
-                               unsigned int             channel_index,
+                               int                      channel_index,
                                int                      layer_index,
+                               bool                     is_virtual_channel,
                                std::list<std::wstring>& tokens)
 {
     const std::vector<std::wstring> parameters(tokens.begin(), tokens.end());
-    const command_context_simple    ctx(std::move(client), channel_index, layer_index, std::move(parameters));
+    const command_context_simple    ctx(
+        std::move(client), channel_index, layer_index, std::move(parameters), is_virtual_channel);
 
     return std::make_shared<AMCPCommand>(ctx, func, name, id);
 }
@@ -52,6 +54,7 @@ AMCPCommand::ptr_type find_command(const std::map<std::wstring, std::pair<amcp_c
                                    IO::ClientInfoPtr                                                client,
                                    int                                                              channel_index,
                                    int                                                              layer_index,
+                                   bool                                                             is_virtual_channel,
                                    std::list<std::wstring>&                                         tokens)
 {
     std::wstring subcommand;
@@ -68,8 +71,14 @@ AMCPCommand::ptr_type find_command(const std::map<std::wstring, std::pair<amcp_c
             tokens.pop_front();
 
             if (tokens.size() >= subcmd->second.second) {
-                return make_cmd(
-                    subcmd->second.first, fullname, request_id, std::move(client), channel_index, layer_index, tokens);
+                return make_cmd(subcmd->second.first,
+                                fullname,
+                                request_id,
+                                std::move(client),
+                                channel_index,
+                                layer_index,
+                                is_virtual_channel,
+                                tokens);
             }
         }
     }
@@ -78,7 +87,14 @@ AMCPCommand::ptr_type find_command(const std::map<std::wstring, std::pair<amcp_c
     const auto command = commands.find(name);
 
     if (command != commands.end() && tokens.size() >= command->second.second) {
-        return make_cmd(command->second.first, name, request_id, std::move(client), channel_index, layer_index, tokens);
+        return make_cmd(command->second.first,
+                        name,
+                        request_id,
+                        std::move(client),
+                        channel_index,
+                        layer_index,
+                        is_virtual_channel,
+                        tokens);
     }
 
     return nullptr;
@@ -96,14 +112,33 @@ bool try_lexical_cast(const In& input, Out& result)
     return success;
 }
 
-static void
-parse_channel_id(std::list<std::wstring>& tokens, std::wstring& channel_spec, int& channel_index, int& layer_index)
+static void parse_channel_id(std::list<std::wstring>& tokens,
+                             std::wstring&            channel_spec,
+                             int&                     channel_index,
+                             int&                     layer_index,
+                             bool&                    is_virtual_channel)
 {
+    is_virtual_channel = false;
+
     if (!tokens.empty()) {
         channel_spec                            = tokens.front();
         std::wstring              channelid_str = boost::trim_copy(channel_spec);
         std::vector<std::wstring> split;
         boost::split(split, channelid_str, boost::is_any_of("-"));
+
+        // Virtual channel spec: $<id> or $<id>-<layer>
+        if (!split[0].empty() && split[0][0] == L'$') {
+            const std::wstring id_str = split[0].substr(1);
+            if (try_lexical_cast(id_str, channel_index)) {
+                is_virtual_channel = true;
+
+                if (split.size() > 1)
+                    try_lexical_cast(split[1], layer_index);
+
+                tokens.pop_front();
+            }
+            return;
+        }
 
         // Use non_throwing lexical cast to not hit exception break point all the time.
         if (try_lexical_cast(split[0], channel_index)) {
@@ -135,7 +170,7 @@ struct amcp_command_repository::impl
                                          IO::ClientInfoPtr        client,
                                          std::list<std::wstring>& tokens) const
     {
-        auto command = find_command(commands, name, id, std::move(client), -1, -1, tokens);
+        auto command = find_command(commands, name, id, std::move(client), -1, -1, false, tokens);
 
         if (command)
             return command;
@@ -146,14 +181,18 @@ struct amcp_command_repository::impl
     AMCPCommand::ptr_type create_channel_command(const std::wstring&      name,
                                                  const std::wstring&      id,
                                                  IO::ClientInfoPtr        client,
-                                                 unsigned int             channel_index,
+                                                 int                      channel_index,
                                                  int                      layer_index,
+                                                 bool                     is_virtual_channel,
                                                  std::list<std::wstring>& tokens) const
     {
-        if (channels_->size() <= channel_index)
+        // Physical channels are bounds-checked here; virtual channels are resolved at execution
+        // time via the virtual_channel_registry, so we don't need (and can't perform) a check here.
+        if (!is_virtual_channel && (channel_index < 0 || channels_->size() <= static_cast<size_t>(channel_index)))
             return nullptr;
 
-        auto command = find_command(channel_commands, name, id, std::move(client), channel_index, layer_index, tokens);
+        auto command = find_command(
+            channel_commands, name, id, std::move(client), channel_index, layer_index, is_virtual_channel, tokens);
 
         if (command)
             return command;
@@ -169,15 +208,17 @@ struct amcp_command_repository::impl
         tokens.pop_front();
 
         // Determine whether the next parameter is a channel spec or not
-        int          channel_index = -1;
-        int          layer_index   = -1;
+        int          channel_index      = -1;
+        int          layer_index        = -1;
+        bool         is_virtual_channel = false;
         std::wstring channel_spec;
-        parse_channel_id(tokens, channel_spec, channel_index, layer_index);
+        parse_channel_id(tokens, channel_spec, channel_index, layer_index, is_virtual_channel);
 
         // Create command instance
         std::shared_ptr<AMCPCommand> command;
         if (channel_index >= 0) {
-            command = create_channel_command(command_name, request_id, client, channel_index, layer_index, tokens);
+            command = create_channel_command(
+                command_name, request_id, client, channel_index, layer_index, is_virtual_channel, tokens);
 
             if (!command) // Might be a non channel command, although the first argument is numeric
             {

--- a/src/protocol/amcp/amcp_command_repository_wrapper.h
+++ b/src/protocol/amcp/amcp_command_repository_wrapper.h
@@ -39,8 +39,14 @@ class command_context_factory
     command_context create(const command_context_simple&                        simple_ctx,
                            const spl::shared_ptr<std::vector<channel_context>>& channels) const
     {
-        const channel_context channel =
-            simple_ctx.channel_index >= 0 ? channels->at(simple_ctx.channel_index) : channel_context();
+        const channel_context channel = [&]() -> channel_context {
+            if (simple_ctx.is_virtual_channel)
+                return static_context_->virtual_channels->get(simple_ctx.channel_index);
+            if (simple_ctx.channel_index >= 0)
+                return channels->at(simple_ctx.channel_index);
+            return channel_context();
+        }();
+
         auto ctx = command_context(
             static_context_, channels, simple_ctx.client, channel, simple_ctx.channel_index, simple_ctx.layer_id);
         ctx.parameters = std::move(simple_ctx.parameters);

--- a/src/protocol/amcp/amcp_shared.h
+++ b/src/protocol/amcp/amcp_shared.h
@@ -33,17 +33,20 @@ struct command_context_simple
     const int                       channel_index;
     const int                       layer_id;
     const std::vector<std::wstring> parameters;
+    const bool                      is_virtual_channel;
 
     int layer_index(int default_ = 0) const { return layer_id == -1 ? default_ : layer_id; }
 
     command_context_simple(IO::ClientInfoPtr                client,
                            int                              channel_index,
                            int                              layer_id,
-                           const std::vector<std::wstring>& parameters)
+                           const std::vector<std::wstring>& parameters,
+                           bool                             is_virtual_channel = false)
         : client(std::move(client))
         , channel_index(channel_index)
         , layer_id(layer_id)
         , parameters(parameters)
+        , is_virtual_channel(is_virtual_channel)
     {
     }
 };

--- a/src/protocol/amcp/virtual_channel_registry.cpp
+++ b/src/protocol/amcp/virtual_channel_registry.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Sveriges Television AB <info@casparcg.com>
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "../StdAfx.h"
+
+#include "virtual_channel_registry.h"
+
+#include <common/except.h>
+
+namespace caspar { namespace protocol { namespace amcp {
+
+virtual_channel_registry::virtual_channel_registry(channel_factory factory)
+    : factory_(std::move(factory))
+{
+}
+
+int virtual_channel_registry::create(const core::video_format_desc& format,
+                                     core::color_space              cs,
+                                     common::bit_depth              depth)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    int                         id = next_id_++;
+    channels_.emplace(id, factory_(id, format, cs, depth));
+    return id;
+}
+
+void virtual_channel_registry::destroy(int id)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    channels_.erase(id);
+}
+
+channel_context virtual_channel_registry::get(int id) const
+{
+    auto ctx = try_get(id);
+    if (!ctx.raw_channel) {
+        CASPAR_THROW_EXCEPTION(user_error()
+                               << msg_info(L"Virtual channel $" + std::to_wstring(id) + L" not found"));
+    }
+    return ctx;
+}
+
+channel_context virtual_channel_registry::try_get(int id) const
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto                        it = channels_.find(id);
+    if (it == channels_.end())
+        return channel_context();
+    return it->second;
+}
+
+}}} // namespace caspar::protocol::amcp

--- a/src/protocol/amcp/virtual_channel_registry.cpp
+++ b/src/protocol/amcp/virtual_channel_registry.cpp
@@ -39,8 +39,19 @@ int virtual_channel_registry::create(const core::video_format_desc& format,
 
 void virtual_channel_registry::destroy(int id)
 {
-    std::lock_guard<std::mutex> lock(mutex_);
-    channels_.erase(id);
+    // Unlink the node under the lock, then let it drop after unlocking. ~video_channel joins
+    // the channel's tick thread, which can be blocked for the deterministic stall timeout
+    // inside wait_for_frame; doing that join while holding mutex_ would stall every other
+    // registry operation (create/get/destroy). extract() unlinks without touching the
+    // (const-membered, non-assignable) channel_context, and the node handle destroys it here.
+    std::map<int, channel_context>::node_type node;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto                        it = channels_.find(id);
+        if (it == channels_.end())
+            return;
+        node = channels_.extract(it);
+    }
 }
 
 channel_context virtual_channel_registry::get(int id) const
@@ -60,6 +71,16 @@ channel_context virtual_channel_registry::try_get(int id) const
     if (it == channels_.end())
         return channel_context();
     return it->second;
+}
+
+std::vector<std::pair<int, std::shared_ptr<core::video_channel>>> virtual_channel_registry::list() const
+{
+    std::vector<std::pair<int, std::shared_ptr<core::video_channel>>> result;
+    std::lock_guard<std::mutex>                                       lock(mutex_);
+    result.reserve(channels_.size());
+    for (const auto& [id, ctx] : channels_) // std::map iterates ascending by id
+        result.emplace_back(id, ctx.raw_channel);
+    return result;
 }
 
 }}} // namespace caspar::protocol::amcp

--- a/src/protocol/amcp/virtual_channel_registry.h
+++ b/src/protocol/amcp/virtual_channel_registry.h
@@ -25,6 +25,8 @@
 #include <functional>
 #include <map>
 #include <mutex>
+#include <utility>
+#include <vector>
 
 namespace caspar { namespace protocol { namespace amcp {
 
@@ -44,6 +46,10 @@ class virtual_channel_registry
 
     // Returns the channel_context for `id`, or an empty channel_context if not found.
     channel_context try_get(int id) const;
+
+    // Snapshot of the live virtual channels (id + channel), ascending by id. Holds a strong
+    // reference to each channel so callers can inspect it without it being torn down underneath.
+    std::vector<std::pair<int, std::shared_ptr<core::video_channel>>> list() const;
 
   private:
     mutable std::mutex                 mutex_;

--- a/src/protocol/amcp/virtual_channel_registry.h
+++ b/src/protocol/amcp/virtual_channel_registry.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 Sveriges Television AB <info@casparcg.com>
+ *
+ * This file is part of CasparCG (www.casparcg.com).
+ *
+ * CasparCG is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * CasparCG is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#pragma once
+
+#include "amcp_shared.h"
+
+#include <common/bit_depth.h>
+#include <core/frame/pixel_format.h>
+#include <core/video_format.h>
+
+#include <functional>
+#include <map>
+#include <mutex>
+
+namespace caspar { namespace protocol { namespace amcp {
+
+class virtual_channel_registry
+{
+  public:
+    using channel_factory = std::function<
+        channel_context(int virtual_id, const core::video_format_desc&, core::color_space, common::bit_depth)>;
+
+    explicit virtual_channel_registry(channel_factory factory);
+
+    int  create(const core::video_format_desc& format, core::color_space cs, common::bit_depth depth);
+    void destroy(int id);
+
+    // Returns the channel_context for `id`, or throws user_error if not found.
+    channel_context get(int id) const;
+
+    // Returns the channel_context for `id`, or an empty channel_context if not found.
+    channel_context try_get(int id) const;
+
+  private:
+    mutable std::mutex                 mutex_;
+    std::map<int, channel_context>     channels_;
+    int                                next_id_ = 1;
+    channel_factory                    factory_;
+};
+
+}}} // namespace caspar::protocol::amcp

--- a/src/protocol/util/AsyncEventServer.cpp
+++ b/src/protocol/util/AsyncEventServer.cpp
@@ -111,6 +111,15 @@ class connection : public spl::enable_shared_from_this<connection>
                 return conn->remove_lifecycle_bound_object(key);
             return std::shared_ptr<void>();
         }
+
+        std::shared_ptr<void> find_lifecycle_bound_object(const std::wstring& key) const override
+        {
+            auto conn = connection_.lock();
+
+            if (conn)
+                return conn->find_lifecycle_bound_object(key);
+            return std::shared_ptr<void>();
+        }
     };
 
   public:
@@ -170,6 +179,16 @@ class connection : public spl::enable_shared_from_this<connection>
             auto result = acc->second;
             lifecycle_bound_objects_.erase(acc);
             return result;
+        }
+        return std::shared_ptr<void>();
+    }
+
+    std::shared_ptr<void> find_lifecycle_bound_object(const std::wstring& key) const
+    {
+        // thread-safe tbb_concurrent_hash_map
+        lifecycle_map_type::const_accessor acc;
+        if (lifecycle_bound_objects_.find(acc, key)) {
+            return acc->second;
         }
         return std::shared_ptr<void>();
     }

--- a/src/protocol/util/ClientInfo.h
+++ b/src/protocol/util/ClientInfo.h
@@ -22,7 +22,9 @@
 #pragma once
 
 #include <iostream>
+#include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 
 #include "protocol_strategy.h"
@@ -35,16 +37,36 @@ typedef std::shared_ptr<client_connection<wchar_t>> ClientInfoPtrStd;
 
 struct ConsoleClientInfo : public client_connection<wchar_t>
 {
+    mutable std::mutex                            lifecycle_mutex_;
+    std::map<std::wstring, std::shared_ptr<void>> lifecycle_objects_;
+
     void send(std::wstring&& data, bool skip_log) override
     {
         std::wcout << L"#" + caspar::log::replace_nonprintable_copy(data, L'?') << std::flush;
     }
     void         disconnect() override {}
     std::wstring address() const override { return L"Console"; }
-    void add_lifecycle_bound_object(const std::wstring& key, const std::shared_ptr<void>& lifecycle_bound) override {}
+
+    void add_lifecycle_bound_object(const std::wstring& key, const std::shared_ptr<void>& lifecycle_bound) override
+    {
+        std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+        lifecycle_objects_[key] = lifecycle_bound;
+    }
     std::shared_ptr<void> remove_lifecycle_bound_object(const std::wstring& key) override
     {
-        return std::shared_ptr<void>();
+        std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+        auto                        it = lifecycle_objects_.find(key);
+        if (it == lifecycle_objects_.end())
+            return {};
+        auto val = it->second;
+        lifecycle_objects_.erase(it);
+        return val;
+    }
+    std::shared_ptr<void> find_lifecycle_bound_object(const std::wstring& key) const override
+    {
+        std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+        auto                        it = lifecycle_objects_.find(key);
+        return it == lifecycle_objects_.end() ? std::shared_ptr<void>() : it->second;
     }
 };
 

--- a/src/protocol/util/protocol_strategy.h
+++ b/src/protocol/util/protocol_strategy.h
@@ -68,6 +68,7 @@ class client_connection
 
     virtual void add_lifecycle_bound_object(const std::wstring& key, const std::shared_ptr<void>& lifecycle_bound) = 0;
     virtual std::shared_ptr<void> remove_lifecycle_bound_object(const std::wstring& key)                           = 0;
+    virtual std::shared_ptr<void> find_lifecycle_bound_object(const std::wstring& key) const                       = 0;
 };
 
 /**

--- a/src/protocol/util/strategy_adapters.cpp
+++ b/src/protocol/util/strategy_adapters.cpp
@@ -90,6 +90,10 @@ class from_unicode_client_connection : public client_connection<wchar_t>
     {
         return client_->remove_lifecycle_bound_object(key);
     }
+    std::shared_ptr<void> find_lifecycle_bound_object(const std::wstring& key) const override
+    {
+        return client_->find_lifecycle_bound_object(key);
+    }
 };
 
 to_unicode_adapter_factory::to_unicode_adapter_factory(

--- a/src/shell/casparcg.config
+++ b/src/shell/casparcg.config
@@ -34,6 +34,8 @@
 <!--
 <log-level> info  [trace|debug|info|warning|error|fatal]</log-level>
 <log-align-columns>true [true|false]</log-align-columns>
+<shutdown-on-eof>false [true|false] (when true, shut down once stdin reaches EOF and no channel has any active consumers - useful for headless recording driven by a piped SCHEDULE script)</shutdown-on-eof>
+<shutdown-on-eof-grace-ms>2000 (how long, in milliseconds, consumer counts must stay at zero after stdin EOF before shutting down; covers AMCP commands queued just before EOF)</shutdown-on-eof-grace-ms>
 <template-hosts>
     <template-host>
         <video-mode />

--- a/src/shell/main.cpp
+++ b/src/shell/main.cpp
@@ -54,6 +54,7 @@
 #include <boost/stacktrace.hpp>
 
 #include <atomic>
+#include <chrono>
 #include <thread>
 
 #include <clocale>
@@ -112,6 +113,13 @@ auto run(const std::wstring& config_file_name, std::atomic<bool>& should_wait_fo
 
     caspar_server->start();
 
+    // Optionally shut the server down once stdin reaches EOF and no consumers remain active.
+    // This enables a headless recording process: pipe a SCHEDULE script in, render to a file
+    // consumer, and let the process terminate on its own once the recording has finished.
+    const bool shutdown_on_eof = env::properties().get(L"configuration.shutdown-on-eof", false);
+    const auto eof_idle_grace =
+        std::chrono::milliseconds(env::properties().get(L"configuration.shutdown-on-eof-grace-ms", 2000));
+
     // Create a dummy client which prints amcp responses to console.
     auto console_client = spl::make_shared<IO::ConsoleClientInfo>();
 
@@ -136,6 +144,22 @@ auto run(const std::wstring& config_file_name, std::atomic<bool>& should_wait_fo
             if (!std::getline(std::cin, cmd1)) { // TODO: It's blocking...
                 if (std::cin.eof()) {
                     std::cin.clear();
+                    if (shutdown_on_eof) {
+                        // Keep running while any channel still has active consumers (e.g. a
+                        // SCHEDULE recording in progress), then shut down. A grace window
+                        // covers the fact that AMCP commands queued just before EOF (such as a
+                        // trailing SCHEDULE COMMIT) attach their consumers asynchronously.
+                        auto last_active = std::chrono::steady_clock::now();
+                        while (true) {
+                            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                            if (caspar_server->active_consumer_count() > 0)
+                                last_active = std::chrono::steady_clock::now();
+                            else if (std::chrono::steady_clock::now() - last_active >= eof_idle_grace)
+                                break;
+                        }
+                        CASPAR_LOG(info) << L"stdin reached EOF and no consumers remain active - shutting down.";
+                        shutdown(false); // false to not restart
+                    }
                     break;
                 }
                 std::cin.clear();

--- a/src/shell/server.cpp
+++ b/src/shell/server.cpp
@@ -441,6 +441,16 @@ struct server::impl
                     }).detach();
                 });
 
+                // If a deterministic render hangs (a producer never delivers), the channel's
+                // watchdog fires this. Destroy the orphaned channel from a detached thread so
+                // ~video_channel does not self-join the channel's own tick thread.
+                channel->set_on_deterministic_stall([virtual_id, registry_weak]() {
+                    std::thread([virtual_id, registry_weak]() {
+                        if (auto r = registry_weak.lock())
+                            r->destroy(virtual_id);
+                    }).detach();
+                });
+
                 const std::wstring lifecycle_key = L"lock-virtual-" + std::to_wstring(virtual_id);
                 return amcp::channel_context(channel, channel->stage(), lifecycle_key);
             });

--- a/src/shell/server.cpp
+++ b/src/shell/server.cpp
@@ -48,6 +48,7 @@
 #include <protocol/amcp/AMCPProtocolStrategy.h>
 #include <protocol/amcp/amcp_command_repository.h>
 #include <protocol/amcp/amcp_shared.h>
+#include <protocol/amcp/virtual_channel_registry.h>
 #include <protocol/osc/client.h>
 #include <protocol/util/AsyncEventServer.h>
 #include <protocol/util/strategy_adapters.h>
@@ -104,6 +105,7 @@ struct server::impl
     std::shared_ptr<amcp::amcp_command_repository>         amcp_command_repo_;
     std::shared_ptr<amcp::amcp_command_repository_wrapper> amcp_command_repo_wrapper_;
     std::shared_ptr<amcp::command_context_factory>         amcp_context_factory_;
+    std::shared_ptr<amcp::virtual_channel_registry>        virtual_channels_;
     std::vector<spl::shared_ptr<IO::AsyncEventServer>>     async_servers_;
     std::shared_ptr<IO::AsyncEventServer>                  primary_amcp_server_;
     std::shared_ptr<osc::client>                           osc_client_ = std::make_shared<osc::client>(io_context_);
@@ -169,6 +171,10 @@ struct server::impl
 
         destroy_producers_synchronously();
         destroy_consumers_synchronously();
+        // Both virtual and physical channels must be torn down AFTER the sync flags
+        // are flipped, so each channel's consumers (file writers etc.) finalise on the
+        // shutting-down thread rather than on detached threads that might outlive main().
+        virtual_channels_.reset();
         channels_->clear();
 
         while (weak_io_context.lock())
@@ -278,6 +284,8 @@ struct server::impl
             if (format_desc.format == video_format::invalid)
                 CASPAR_THROW_EXCEPTION(user_error() << msg_info(L"Invalid video-mode: " + format_desc_str));
 
+            auto deterministic = xml_channel.second.get(L"deterministic", false);
+
             auto weak_client = std::weak_ptr<osc::client>(osc_client_);
             auto channel_id  = static_cast<int>(channels_->size() + 1);
             auto depth       = color_depth == 16 ? common::bit_depth::bit16 : common::bit_depth::bit8;
@@ -287,6 +295,7 @@ struct server::impl
                 spl::make_shared<video_channel>(channel_id,
                                                 format_desc,
                                                 default_color_space,
+                                                deterministic,
                                                 accelerator_.create_image_mixer(channel_id, depth),
                                                 [channel_id, weak_client](core::monitor::state channel_state) {
                                                     monitor::state state;
@@ -409,6 +418,33 @@ struct server::impl
     {
         amcp_command_repo_ = std::make_shared<amcp::amcp_command_repository>(channels_);
 
+        virtual_channels_ =
+            std::make_shared<amcp::virtual_channel_registry>([this](int                            virtual_id,
+                                                                    const core::video_format_desc& format_desc,
+                                                                    core::color_space              cs,
+                                                                    common::bit_depth depth) -> amcp::channel_context {
+                auto channel = spl::make_shared<video_channel>(virtual_id,
+                                                               format_desc,
+                                                               cs,
+                                                               /*deterministic*/ true,
+                                                               accelerator_.create_image_mixer(virtual_id, depth),
+                                                               [](core::monitor::state) {});
+
+                // If the (only) consumer on this virtual channel errors out during send(),
+                // the render is over and the channel is orphaned. Tear it down from a detached
+                // thread so ~video_channel does not self-join the channel's own tick thread.
+                std::weak_ptr<amcp::virtual_channel_registry> registry_weak = virtual_channels_;
+                channel->output().set_on_consumer_error([virtual_id, registry_weak](int) {
+                    std::thread([virtual_id, registry_weak]() {
+                        if (auto r = registry_weak.lock())
+                            r->destroy(virtual_id);
+                    }).detach();
+                });
+
+                const std::wstring lifecycle_key = L"lock-virtual-" + std::to_wstring(virtual_id);
+                return amcp::channel_context(channel, channel->stage(), lifecycle_key);
+            });
+
         auto ogl_device = accelerator_.get_device();
         auto ctx        = std::make_shared<amcp::amcp_command_static_context>(
             video_format_repository_,
@@ -416,6 +452,7 @@ struct server::impl
             producer_registry_,
             consumer_registry_,
             amcp_command_repo_,
+            virtual_channels_,
             shutdown_server_now_,
             u8(caspar::env::properties().get(L"configuration.amcp.media-server.host", L"127.0.0.1")),
             u8(caspar::env::properties().get(L"configuration.amcp.media-server.port", L"8000")),

--- a/src/shell/server.cpp
+++ b/src/shell/server.cpp
@@ -507,6 +507,25 @@ struct server::impl
         }
     }
 
+    size_t active_consumer_count() const
+    {
+        size_t count = 0;
+
+        for (const auto& channel : *channels_) {
+            if (channel.raw_channel)
+                count += channel.raw_channel->output().consumer_count();
+        }
+
+        if (virtual_channels_) {
+            for (const auto& [id, channel] : virtual_channels_->list()) {
+                if (channel)
+                    count += channel->output().consumer_count();
+            }
+        }
+
+        return count;
+    }
+
     IO::protocol_strategy_factory<char>::ptr create_protocol(const std::wstring& name,
                                                              const std::wstring& port_description) const
     {
@@ -528,5 +547,6 @@ spl::shared_ptr<protocol::amcp::amcp_command_repository> server::get_amcp_comman
 {
     return spl::make_shared_ptr(impl_->amcp_command_repo_);
 }
+size_t server::active_consumer_count() const { return impl_->active_consumer_count(); }
 
 } // namespace caspar

--- a/src/shell/server.h
+++ b/src/shell/server.h
@@ -35,6 +35,9 @@ class server final
     void                                                     start();
     spl::shared_ptr<protocol::amcp::amcp_command_repository> get_amcp_command_repository() const;
 
+    // Number of currently-attached consumers across all physical and virtual channels.
+    size_t active_consumer_count() const;
+
   private:
     struct impl;
     std::shared_ptr<impl> impl_;


### PR DESCRIPTION
Adds deterministic rendering

* Introduce the SCHEDULE command suite to schedule commands that will be recorded in non-realtime. 
* SCHEDULED commands are invoked on a virtual channel, unique for each SCHEDULE session. Use the $ channel placeholder to schedule commands in the active schedule session
* Producers get to take as long as they need to produce a frame, and the channel doesn't tick until all registered producers have delivered a frame
* Support for virtual time in the html producer, which means that caspar explicitly ticks cef with the correct amount of time between frames
    * video- and audio- elements are not supported by this
* Introduce the 'shutdown-on-eof' setting, which enables workflows where a batch of SCHEDULE commands are piped in to a fresh casparcg process, which then terminates when the recording is completed

To get started:
1. create a config without any channels
2. set `configuration.html.wait-for-fp=true` and `configuration.html.enable-virtual-time=true`
3. set `configuration.shutdown-on-eof=true` and `configuration.shutdown-on-eof-grace-ms=500`
4. Create a text-file with schedule commands. For example:
    ```
    SCHEDULE BEGIN 1080p5000 ADD FILE record.mp4 -codec:a aac -b:a 128k -filter:a pan=stereo|c0=c0|c1=c1 -codec:v libx264 -filter:v format=yuv420p
    SCHEDULE FRAME 0 PLAY $-10 2_h264_hdr
    SCHEDULE FRAME 0 CG $-23 ADD 1 infobox/index 1 "<templateData>eyJoZWFkbGluZSI6ImF3ZGF3ZGF3ZHdhZHdhZHdhZHdhZGF3Iiwic3VidCI6IiIsImhvc3QxIjoiIiwiaG9zdDIiOiIiLCJlbW5lIjoic2Vmc2VmIiwiZW1uZUNvbG9yIjoidG9tIiwiaGlzdG9yeSI6bnVsbCwiX3ZmIjoibnVsbCIsIl9hZiI6ImFudWxsIiwiX2R1cmF0aW9uIjpudWxsLCJfc2NhbGVfbW9kZSI6ImZpdCIsIl9zZWVrIjowfQ==</templateData>"
    SCHEDULE FRAME 0 MIXER $-23 OPACITY 0.5
    SCHEDULE FRAME 100 MIXER $-23 OPACITY 1 100
    SCHEDULE FRAME 200 PLAY $-10 4k MIX 50
    SCHEDULE FRAME 300 CG $-23 STOP 1
    SCHEDULE END 350 COMMIT
    ```
5. run `casparcg casparcg-record.config < schedule.txt`. It should record 350 frames to `record.mp4` and terminate when ready.

Leaving this as draft until more tests has been performed